### PR TITLE
Add update manager

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -108,6 +108,7 @@ set(viewer_SOURCE_FILES
     alstreaminfo.cpp
     altoolalign.cpp
     alunzip.cpp
+    alupdatemanager.cpp
     alviewermenu.cpp
     bdanimator.cpp
     bdfloaterposer.cpp
@@ -854,6 +855,7 @@ set(viewer_HEADER_FILES
     alstreaminfo.h
     altoolalign.h
     alunzip.h
+    alupdatemanager.h
     alviewermenu.h
     bdanimator.h
     bdfloaterposer.h

--- a/indra/newview/alupdatemanager.cpp
+++ b/indra/newview/alupdatemanager.cpp
@@ -1,0 +1,256 @@
+/**
+ * @file alupdatemanager.h
+ * @brief Manager for updating!
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2024, Kyler "Felix" Eastridge.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * $/LicenseInfo$
+ */
+
+#include "alupdatemanager.h"
+#include "llversioninfo.h"
+#include "llviewercontrol.h"
+#include "llcorehttputil.h"
+#include "llsdserialize.h"
+#include "llsdutil.h"
+#include "llnotificationmanager.h"
+#include "llnotifications.h"
+#include "llnotificationsutil.h"
+#include "llappviewer.h" // For gDisconnected
+#include "llweb.h"
+#include "llstartup.h"
+
+/*
+Current LLSD data template:
+
+<llsd>
+  <map>
+    <!-- Put all entries in a sub map called "channels", in case we want to
+         include something else shared between all channels. -->
+    <key>channels</key>
+    <map>
+      <key>Alchemy Test</key>
+      <map>
+        <!-- Build ID, viewer checks if this is newer -->
+        <key>build</key>
+        <integer>123456</integer>
+
+        <!-- Full version number -->
+        <key>version</key>
+        <string>1.2.3.45678</string>
+
+        <!-- A URL to the download page -->
+        <key>download</key>
+        <string>Page to open in browser when user clicks "download"</string>
+
+        <!-- A optional message -->
+        <key>message</key>
+        <string>Coyito was here!</string>
+      </map>
+    </map>
+  </map>
+</llsd>
+*/
+
+ALUpdateManager::ALUpdateManager() :
+    mChecking(false),
+    mSupressAuto(false),
+    mFirstCheck(true),
+    mUpdateAvailable(false),
+    mUpdateVersion(""),
+    mUpdateURL(""),
+    mAddMessage("")
+{
+}
+
+ALUpdateManager::~ALUpdateManager()
+{
+}
+
+void ALUpdateManager::showNotification()
+{
+    // If we already have one, don't grief the user.
+    if (mNotification && mNotification->isActive())
+        return;
+
+    LLSD args;
+    args["CHANNEL"] = LLVersionInfo::instance().getChannel();
+    args["VERSION"] = mUpdateVersion;
+    args["MYVERSION"] = LLVersionInfo::instance().getVersion();
+    args["URL"] = mUpdateURL;
+    args["MESSAGE"] = mAddMessage;
+    if (LLStartUp::getStartupState() < STATE_LOGIN_CLEANUP)
+        mNotification = LLNotificationsUtil::add("AlchemyUpdateAlert", args);
+    else
+        mNotification = LLNotificationsUtil::add("AlchemyUpdateToast", args);
+}
+
+void ALUpdateManager::handleUpdateData(const LLSD& content)
+{
+    // Check if we have a channel in the list
+    std::string channel = LLVersionInfo::instance().getChannel();
+    if (!content.has(channel))
+        return;
+
+    // Make sure we have a build number
+    if (!content[channel].has("build"))
+        return;
+
+    // Make sure the build number is newer than the one we have
+    int build = LLVersionInfo::instance().getBuild();
+    if (content[channel]["build"].asInteger() <= build)
+        return;
+
+    //Make sure we have all the remaining fields
+    if (!content[channel].has("version"))
+        return;
+
+    if (!content[channel].has("download"))
+        return;
+
+    LL_INFOS("ALUpdateManager") << "Update detected! 🥳" << LL_ENDL;
+
+    // And now only, and only if we got this far, update the variables
+    mUpdateVersion = content[channel]["version"].asString();
+    mUpdateURL = content[channel]["download"].asString();
+
+    if (content[channel].has("message"))
+        mAddMessage = "\n\n" + content[channel]["message"].asString();
+    else
+        mAddMessage = "";
+
+    // And mark that we have a update ready!
+    mUpdateAvailable = true;
+
+    showNotification();
+}
+
+void ALUpdateManager::launchRequest()
+{
+    LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
+    LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t
+        httpAdapter(new LLCoreHttpUtil::HttpCoroutineAdapter("ALUpdateManager", httpPolicy));
+    LLCore::HttpRequest::ptr_t httpRequest(new LLCore::HttpRequest);
+    LLCore::HttpOptions::ptr_t httpOpts(new LLCore::HttpOptions);
+
+    // If we change the URL
+    httpOpts->setFollowRedirects(true);
+
+    // Also try again if we fail the first time, just in case
+    httpOpts->setRetries(1);
+
+    static LLCachedControl<std::string> AlchemyUpdateURL(gSavedSettings, "AlchemyUpdateURL");
+    LL_INFOS("ALUpdateManager") << "Launching update check to " << AlchemyUpdateURL() << LL_ENDL;
+    LLSD result = httpAdapter->getRawAndSuspend(httpRequest, AlchemyUpdateURL);
+
+
+    LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
+    LLCore::HttpStatus status = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(httpResults);
+
+    // Mark we aren't checking anymore first and reset the timer, just in case
+    // we end up bailing due to HTTP failure
+    ALUpdateManager::getInstance()->mChecking = false;
+    ALUpdateManager::getInstance()->mLastChecked.reset();
+
+    if (!status)
+    {
+        LL_WARNS("ALUpdateManager") << "HTTP status, " << status.toTerseString() <<
+            ". Update check failed." << LL_ENDL;
+        return;
+    }
+
+    const LLSD::Binary &rawBody = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS_RAW].asBinary();
+    std::string body(rawBody.begin(), rawBody.end());
+    std::istringstream is(body);
+
+    LLPointer<LLSDParser> parser = new LLSDXMLParser();
+    LLSD data;
+    if(parser->parse(is, data, body.size()) == LLSDParser::PARSE_FAILURE)
+    {
+        LL_WARNS("ALUpdateManager") << "Failed to parse update info: " << ll_stream_notation_sd(result) << LL_ENDL;
+        return;
+    }
+
+    LL_INFOS("ALUpdateManager") << "Got response: " << ll_stream_notation_sd(data) << LL_ENDL;
+
+    if (data.has("channels"))
+        ALUpdateManager::getInstance()->handleUpdateData(data["channels"]);
+    //Handle anything else here
+}
+
+void ALUpdateManager::checkNow()
+{
+    // No need to check when we are disconnected
+    if(gDisconnected)
+        return;
+
+    // Bail out if we are already checking
+    if (mChecking)
+        return;
+
+    mChecking = true;
+
+    LL_INFOS("ALUpdateManager") << "Checking for update..." << LL_ENDL;
+    LLCoros::instance().launch("ALUpdateManager::LaunchRequest",
+        boost::bind(ALUpdateManager::launchRequest));
+}
+
+void ALUpdateManager::tryAutoCheck()
+{
+    if (mSupressAuto)
+        return;
+
+    // Don't check if the user has requested to disable it
+    static LLCachedControl<bool> AlchemyUpdateEnableAutoCheck(gSavedSettings, "AlchemyUpdateEnableAutoCheck");
+    if (!AlchemyUpdateEnableAutoCheck)
+        return;
+
+    static LLCachedControl<F32> AlchemyUpdateCheckFrequency(gSavedSettings, "AlchemyUpdateCheckFrequency");
+    if ((mLastChecked.getElapsedTimeF32() < AlchemyUpdateCheckFrequency || AlchemyUpdateCheckFrequency == .0f)
+        && !mFirstCheck)
+        return;
+
+    mFirstCheck = false;
+
+    LL_INFOS("ALUpdateManager") << "Attempting automatic update check..." << LL_ENDL;
+    checkNow();
+}
+
+static bool AlchemyUpdateToastlert(const LLSD& notification, const LLSD& response)
+{
+    std::string option = LLNotification::getSelectedOptionName(response);
+
+    if (option == "DOWNLOAD")
+    {
+        LLWeb::loadURLExternal(ALUpdateManager::getInstance()->mUpdateURL);
+    }
+    else if (option == "CLOSE")
+    {
+        // This is the remind me later option
+        // We don't really do anything here, instead we just wait for the next
+        // tryAutoCheck.
+    }
+    else if (option == "SUPPRESS")
+    {
+        ALUpdateManager::getInstance()->mSupressAuto = true;
+    }
+    return false;
+}
+static LLNotificationFunctorRegistration AlchemyUpdateAlert_reg("AlchemyUpdateAlert", AlchemyUpdateToastlert);
+static LLNotificationFunctorRegistration AlchemyUpdateToast_reg("AlchemyUpdateToast", AlchemyUpdateToastlert);

--- a/indra/newview/alupdatemanager.h
+++ b/indra/newview/alupdatemanager.h
@@ -1,0 +1,58 @@
+/**
+ * @file alupdatemanager.h
+ * @brief Manager for updating!
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2024, Kyler "Felix" Eastridge.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * $/LicenseInfo$
+ */
+
+#ifndef LL_ALUPDATEMANAGER_H
+#define LL_ALUPDATEMANAGER_H
+
+#include "llsingleton.h"
+#include "llnotificationptr.h"
+
+class ALUpdateManager final : public LLSingleton<ALUpdateManager>
+{
+    LLSINGLETON(ALUpdateManager);
+public:
+    ~ALUpdateManager();
+    void showNotification();
+    void handleUpdateData(const LLSD& content);
+    static void launchRequest();
+    void checkNow();
+    void tryAutoCheck();
+
+// Portion used for checking updates
+    bool            mFirstCheck;
+    bool            mSupressAuto;
+    bool            mChecking;
+    LLTimer         mLastChecked;
+
+// Portion used if we have a update
+    bool            mUpdateAvailable;
+    bool            getUpdateAvailable(){ return mUpdateAvailable; }
+    std::string     mUpdateVersion;
+    std::string     mUpdateURL;
+    std::string     mAddMessage; // Optional message regarding the update
+    LLNotificationPtr mNotification;
+};
+
+#endif // LL_ALUPDATEMANAGER_H

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -1445,6 +1445,39 @@
 			<key>Value</key>
 			<real>8.0</real>
 		</map>
+		<key>AlchemyUpdateCheckFrequency</key>
+		<map>
+			<key>Comment</key>
+			<string>How often to check for updates</string>
+			<key>Persist</key>
+			<integer>1</integer>
+			<key>Type</key>
+			<string>F32</string>
+			<key>Value</key>
+			<real>3600.0</real>
+		</map>
+		<key>AlchemyUpdateEnableAutoCheck</key>
+		<map>
+			<key>Comment</key>
+			<string>Enable update notifications</string>
+			<key>Persist</key>
+			<integer>1</integer>
+			<key>Type</key>
+			<string>Boolean</string>
+			<key>Value</key>
+			<real>1</real>
+		</map>
+		<key>AlchemyUpdateURL</key>
+		<map>
+			<key>Comment</key>
+			<string>URL to pull update checks from</string>
+			<key>Persist</key>
+			<integer>1</integer>
+			<key>Type</key>
+			<string>String</string>
+			<key>Value</key>
+			<string>https://crocuta.softhyena.com/alupdate.xml</string>
+		</map>
 		<key>ResetUserColorsOnLogout</key>
 		<map>
 			<key>Comment</key>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -270,6 +270,8 @@ using namespace LL;
 
 #include "alstreaminfo.h"
 
+#include "alupdatemanager.h"
+
 // *FIX: These extern globals should be cleaned up.
 // The globals either represent state/config/resource-storage of either
 // this app, or another 'component' of the viewer. App globals should be
@@ -4644,6 +4646,9 @@ void LLAppViewer::idle()
     // Must wait until both have avatar object and mute list, so poll
     // here.
     LLIMProcessing::requestOfflineMessages();
+
+    // Check if it is time to do a update check
+    ALUpdateManager::getInstance()->tryAutoCheck();
 
     ///////////////////////////////////
     //

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -90,6 +90,7 @@
 #include "llrect.h"
 #include "llstring.h"
 #include "alunzip.h"
+#include "alupdatemanager.h"
 
 // project includes
 
@@ -346,6 +347,7 @@ LLFloaterPreference::LLFloaterPreference(const LLSD& key)
     mCommitCallbackRegistrar.add("Pref.getUIColor",             boost::bind(&LLFloaterPreference::getUIColor, this ,_1, _2));
     mCommitCallbackRegistrar.add("Pref.MaturitySettings",       boost::bind(&LLFloaterPreference::onChangeMaturity, this));
     mCommitCallbackRegistrar.add("Pref.BlockList",              boost::bind(&LLFloaterPreference::onClickBlockList, this));
+    mCommitCallbackRegistrar.add("Pref.UpdateCheckNow",         boost::bind(&LLFloaterPreference::onClickUpdateCheckNow, this));
     mCommitCallbackRegistrar.add("Pref.Proxy",                  boost::bind(&LLFloaterPreference::onClickProxySettings, this));
     mCommitCallbackRegistrar.add("Pref.TranslationSettings",    boost::bind(&LLFloaterPreference::onClickTranslationSettings, this));
     mCommitCallbackRegistrar.add("Pref.AutoReplace",            boost::bind(&LLFloaterPreference::onClickAutoReplace, this));
@@ -960,6 +962,16 @@ void LLFloaterPreference::draw()
 
     has_first_selected = (getChildRef<LLScrollListCtrl>("enabled_popups").getFirstSelected()!=NULL);
     gSavedSettings.setBOOL("FirstSelectedEnabledPopups", has_first_selected);
+
+    getChild<LLButton>("AlchemyUpdateCheckNow")->setEnabled(!ALUpdateManager::getInstance()->mChecking);
+    static LLCachedControl<bool> AlchemyUpdateEnableAutoCheck(gSavedSettings, "AlchemyUpdateEnableAutoCheck");
+    getChild<LLTextBase>("AlchemyUpdateLastChecked")->setVisible(AlchemyUpdateEnableAutoCheck);
+    if (AlchemyUpdateEnableAutoCheck)
+    {
+        std::string lastCheck = LLTrans::getString("LastCheckedNSecondsAgo");
+        LLStringUtil::format(lastCheck, LLSD().with("SECONDS", static_cast<S32>(ALUpdateManager::getInstance()->mLastChecked.getElapsedTimeF32())));
+        getChild<LLTextBase>("AlchemyUpdateLastChecked")->setText(lastCheck);
+    }
 
     LLFloater::draw();
 }
@@ -2117,6 +2129,11 @@ void LLFloaterPreference::onClickBlockList()
 // [/SL:KB]
 //  LLFloaterSidePanelContainer::showPanel("people", "panel_people",
 //      LLSD().with("people_panel_tab_name", "blocked_panel"));
+}
+
+void LLFloaterPreference::onClickUpdateCheckNow()
+{
+    ALUpdateManager::getInstance()->checkNow();
 }
 
 void LLFloaterPreference::onClickProxySettings()

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -182,6 +182,7 @@ public:
     void onChangeSoundFolder();
     void onChangeAnimationFolder();
     void onClickBlockList();
+    void onClickUpdateCheckNow();
     void onClickProxySettings();
     void onClickTranslationSettings();
     void onClickPermsDefault();

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -13207,6 +13207,51 @@ Always Run disabled.
   type="notifytip">
 	 I’m sorry Dave, I’m afraid I can’t do that
  </notification>
+
+  <notification
+   icon="alertmodal.tga"
+   name="AlchemyUpdateAlert"
+   type="alertmodal">
+A new version of [APP_NAME] is available for download!
+
+Latest: [CHANNEL] [VERSION]
+You have: [CHANNEL] [MYVERSION][MESSAGE]
+    <form name="form">
+      <button
+       default="true"
+       index="0"
+       name="DOWNLOAD"
+       text="Download"/>
+      <button
+       index="1"
+       name="CLOSE"
+       text="Remind Me Later"/>
+      <button
+       index="2"
+       name="SUPPRESS"
+       text="Ignore"/>
+    </form>
+  </notification>
+  <notification
+   icon="notify.tga"
+   name="AlchemyUpdateToast"
+   persist="true"
+   type="offer">
+A new version of [APP_NAME] is available for download!
+
+Latest: [CHANNEL] [VERSION]
+You have: [CHANNEL] [MYVERSION][MESSAGE]
+    <form name="form">
+      <button
+       index="0"
+       name="DOWNLOAD"
+       text="Download"/>
+      <button
+       index="2"
+       name="SUPPRESS"
+       text="Ignore"/>
+    </form>
+  </notification>
 	
  <notification
   icon="notifytip.tga"

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -13235,7 +13235,7 @@ You have: [CHANNEL] [MYVERSION][MESSAGE]
   <notification
    icon="notify.tga"
    name="AlchemyUpdateToast"
-   persist="true"
+   persist="false"
    type="offer">
 A new version of [APP_NAME] is available for download!
 

--- a/indra/newview/skins/default/xui/en/panel_preferences_setup.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_setup.xml
@@ -166,7 +166,7 @@
      type="string"
      length="1"
      follows="left|top"
-     height="10"
+     height="15"
      layout="topleft"
      left="30"
      name="Software updates:"
@@ -185,13 +185,14 @@
     left_delta="50"
     mouse_opaque="true"
     name="alchemy_updates_auto_check"
-    width="400"
+    width="50"
     top_pad="10"/>
   <text
-    left_delta="205"
+    follows="left|top"
+    layout="topleft"
     top_delta="-2"
-    width="100"
-    follows="left|top">
+    left_pad="155"
+    width="100">
       ([https://alchemyviewer.org/privacy-policy Privacy Policy])
   </text>
 

--- a/indra/newview/skins/default/xui/en/panel_preferences_setup.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_setup.xml
@@ -102,7 +102,7 @@
          layout="topleft"
          left="30"
          name="Web:"
-         top_pad="5"
+         top_pad="10"
          width="300">
     Web:
   </text>
@@ -113,7 +113,7 @@
    layout="topleft"
    left_delta="50"
    name="preferred_browser_behavior"
-   top_pad="0"
+   top_pad="5"
    width="480">
     <radio_item
       height="20"
@@ -161,7 +161,8 @@
     radio_style="false"
     width="400"
     top_pad="5"/>
-  <!--<text
+
+  <text
      type="string"
      length="1"
      follows="left|top"
@@ -170,10 +171,31 @@
      left="30"
      name="Software updates:"
      mouse_opaque="false"
-     top_pad="5"
+     top_pad="10"
      width="300">
     Software updates:
   </text>
+  <check_box
+    top_delta="4"
+    enabled="true"
+    follows="left|top"
+    height="14"
+    control_name="AlchemyUpdateEnableAutoCheck"
+    label="Automatically check for updates"
+    left_delta="50"
+    mouse_opaque="true"
+    name="alchemy_updates_auto_check"
+    width="400"
+    top_pad="10"/>
+  <text
+    left_delta="205"
+    top_delta="-2"
+    width="100"
+    follows="left|top">
+      ([https://alchemyviewer.org/privacy-policy Privacy Policy])
+  </text>
+
+  <!--
   <combo_box
      control_name="AlchemyUpdatePreference"
      follows="left|top"
@@ -217,7 +239,7 @@
      left="30"
      name="Proxy Settings:"
      mouse_opaque="false"
-     top_pad="5"
+     top_pad="10"
      width="300">
 		Proxy Settings:
   </text>
@@ -230,7 +252,7 @@
     layout="topleft"
     left_delta="50"
     name="set_proxy"
-    top_pad="5"
+    top_pad="10"
     >
 		<button.commit_callback
 		  function="Pref.Proxy" />

--- a/indra/newview/skins/default/xui/en/panel_preferences_setup.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_setup.xml
@@ -195,6 +195,28 @@
     width="100">
       ([https://alchemyviewer.org/privacy-policy Privacy Policy])
   </text>
+  <button
+    label="Check now"
+    follows="top|left"
+    height="23"
+    width="100"
+    label_selected="Check now"
+    layout="topleft"
+    top_delta="0"
+    left="100"
+    name="AlchemyUpdateCheckNow"
+    top_pad="10"
+    >
+        <button.commit_callback
+            function="Pref.UpdateCheckNow" />
+  </button>
+  <text
+    follows="left|top"
+    layout="topleft"
+    top_delta="4"
+    left_pad="10"
+    name="AlchemyUpdateLastChecked"
+    width="200"></text>
 
   <!--
   <combo_box
@@ -240,7 +262,7 @@
      left="30"
      name="Proxy Settings:"
      mouse_opaque="false"
-     top_pad="10"
+     top_pad="15"
      width="300">
 		Proxy Settings:
   </text>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -4471,6 +4471,7 @@ and report the problem.
   <string name="NotAvailableOnPlatform">Not availalbe on this platform</string>
   <string name="NowPlaying">Now Playing</string>
   <string name="GridInfoTitle">GRID INFO</string>
+  <string name="LastCheckedNSecondsAgo">Last checked [SECONDS] seconds ago.</string>
 
   <!-- <LSL Preprocessor -->
   <string name="preproc_toggle_warning">Toggling the preprocessor will not take full effect until you close and reopen this editor.</string>


### PR DESCRIPTION
Wowe now people can be notified when there is a update available!

Despite the name, this doesn't do automated updates. Depending on who you ask, this will be disappointing or a benefit.

# IMPORTANT
`indra/newview/app_settings/settings_alchemy.xml` needs to be changed!
Specifically the `AlchemyUpdateURL` key. Which currently points to my server for testing.

## alsetup.xml syntax
The correct XML format is documented in a comment at `indra/newview/alupdatemanager.cpp`, which at the time is currently:
```xml
<llsd>
  <map>
    <!-- Put all entries in a sub map called "channels", in case we want to
         include something else shared between all channels. -->
    <key>channels</key>
    <map>
      <key>Alchemy Test</key>
      <map>
        <!-- Build ID, viewer checks if this is newer -->
        <key>build</key>
        <integer>123456</integer>

        <!-- Full version number -->
        <key>version</key>
        <string>1.2.3.45678</string>

        <!-- A URL to the download page -->
        <key>download</key>
        <string>Page to open in browser when user clicks "download"</string>

        <!-- A optional message -->
        <key>message</key>
        <string>Coyito was here!</string>
      </map>
    </map>
  </map>
</llsd>
```

## This adds the following automated update check:
1. Disable automatic update checks if `AlchemyUpdateEnableAutoCheck` is set to true (This is configurable in the "Setup" preferences tab. A "Privacy Policy" link is also included).
2. Upon start up, check as soon as possible for a update.
3. After the first check, check every `AlchemyUpdateCheckFrequency` seconds (Default is 3600 seconds, or 1 hour). This can also be set to 0 to not do timed checks (I.E. Only check on start up).
4. If the user chooses "Ignore" on the dialog, it will suppress update notifications for that session. It is not possible to ignore a entire update because we only support the latest version of each channel IIRC.
5. If a update is detected on the login screen, the user is notified via a pop up.
6. If a update is detected while logged in, the user is notified via a system toast.

## New alchemy_settings.xml keys:
* `AlchemyUpdateURL` - (string) path to update XML url.
* `AlchemyUpdateEnableAutoCheck` - (bool) If update checks are enabled.
* `AlchemyUpdateCheckFrequency` - (float) How often in seconds to check for updates.

## New notifications:
* `AlchemyUpdateAlert` - Popup notification for login screen
* `AlchemyUpdateToast` - Toast notification for in-world

## New preference settings:
* `Setup > Software Updates` - A option to disable notification checks (for privacy concerned residents). Privacy policy is also linked next to this.
* `Setup > Software Updates` - A "Check now" button as well as a last checked timer.