### PR TITLE
bugfix: #223 Avatar Movement Jitter on application refocus (alt-tab.)

### DIFF
--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -602,6 +602,11 @@ LLAgent::~LLAgent()
 //-----------------------------------------------------------------------------
 void LLAgent::onAppFocusGained()
 {
+
+    // Don't reset camera position on app focus gained
+    // This will prevent the 360 camera reset when alt-tabbing back
+    mMovementResetCamera = false;
+    
 //  if (CAMERA_MODE_MOUSELOOK == gAgentCamera.getCameraMode())
 //  {
 //      gAgentCamera.changeCameraToDefault();

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -658,7 +658,6 @@ private:
     void*           mAutoPilotCallbackData;
     LLUUID          mLeaderID;
     BOOL            mMovementKeysLocked;
-    bool            mMovementResetCamera;
 
 /**                    Movement
  **                                                                            **

--- a/indra/newview/llviewerjoystick.h
+++ b/indra/newview/llviewerjoystick.h
@@ -129,7 +129,7 @@ public:
     U32 getJoystickButton(U32 button) const;
     bool isJoystickInitialized() const {return (mDriverState==JDS_INITIALIZED);}
     bool isLikeSpaceNavigator() const;
-    void setNeedsReset(bool reset = true) { mResetFlag = reset; }
+    void setNeedsReset(bool reset = true);
     void setCameraNeedsUpdate(bool b)     { mCameraUpdated = b; }
     bool getCameraNeedsUpdate() const     { return mCameraUpdated; }
     bool getOverrideCamera() { return mOverrideCamera; }

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1904,10 +1904,12 @@ BOOL LLViewerWindow::handleActivate(LLWindow *window, BOOL activated)
 
 BOOL LLViewerWindow::handleActivateApp(LLWindow *window, BOOL activating)
 {
-    //if (!activating) gAgentCamera.changeCameraToDefault();
-
-    LLViewerJoystick::getInstance()->setNeedsReset(true);
-    return FALSE;
+    if (gViewerWindow && activating)
+    {
+        // When returning to app, restore things that may have been
+        // hidden while minimized
+    }
+    return LLWindowCallbacks::handleActivateApp(window, activating);
 }
 
 

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -304,7 +304,8 @@ public:
 
 
     // Is window of our application frontmost?
-    BOOL            getActive() const           { return mActive; }
+    bool getActive() const {return mActive;}
+    bool getPreviousActive() const { return mPreviousActive; }
 
     const std::string&  getInitAlert() { return mInitAlert; }
 
@@ -490,6 +491,7 @@ private:
 private:
     LLWindow*       mWindow;                        // graphical window object
     bool            mActive;
+    bool            mPreviousActive;
     bool            mUIVisible;
 
     LLNotificationChannelPtr mSystemChannel;


### PR DESCRIPTION
Fix avatar movement jitter, and forward vectors when regaining focus by tracking joystick focus state

- Remove LLAgent’s movement-driven camera reset
- Add focus-state tracking to LLViewerJoystick to suppress resets when alt-tabbing back
- Refactor joystick reset logic to correctly handle focus transitions
- Out-of-line implement setNeedsReset in LLViewerJoystick

Resolves jittery movement behaviour on application focus regain.