### PR TITLE
[FEAT] Reject Adhoc Messages

### DIFF
--- a/indra/newview/app_settings/settings_per_account_alchemy.xml
+++ b/indra/newview/app_settings/settings_per_account_alchemy.xml
@@ -319,5 +319,38 @@
             <key>Value</key>
             <string>This resident has turned on &apos;Autorespond mode&apos; like a boss.</string>
         </map>
+        <key>AlchemyIgnoreAdHocSessions</key>
+        <map>
+            <key>Comment</key>
+            <string>Automatically ignore and leave all conference (ad-hoc) chats.</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>Boolean</string>
+            <key>Value</key>
+            <integer>0</integer>
+        </map>
+        <key>AlchemyReportIgnoredAdHocSession</key>
+        <map>
+            <key>Comment</key>
+            <string>Reports to nearby chat if a conference (ad-hoc) has been ignored.</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>Boolean</string>
+            <key>Value</key>
+            <integer>0</integer>
+        </map>
+        <key>AlchemyDontIgnoreAdHocFromFriends</key>
+        <map>
+            <key>Comment</key>
+            <string>Allow my friends to start conference chats with me.</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>Boolean</string>
+            <key>Value</key>
+            <integer>0</integer>
+        </map>
     </map>
 </llsd>

--- a/indra/newview/app_settings/settings_per_account_alchemy.xml
+++ b/indra/newview/app_settings/settings_per_account_alchemy.xml
@@ -326,7 +326,7 @@
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
-            <string>Boolean</string>
+            <string>S32</string>
             <key>Value</key>
             <integer>0</integer>
         </map>
@@ -334,17 +334,6 @@
         <map>
             <key>Comment</key>
             <string>Reports to nearby chat if a conference (ad-hoc) has been ignored.</string>
-            <key>Persist</key>
-            <integer>1</integer>
-            <key>Type</key>
-            <string>Boolean</string>
-            <key>Value</key>
-            <integer>0</integer>
-        </map>
-        <key>AlchemyDontIgnoreAdHocFromFriends</key>
-        <map>
-            <key>Comment</key>
-            <string>Allow my friends to start conference chats with me.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -447,6 +447,9 @@ LLAgent::LLAgent() :
     mIsAutoRespond(false),
     mIsAutoRespondNonFriends(false),
     
+    mIsRejectingConferences(false),
+    mIsAllowingConferenceFromFriends(false),
+
     mIsDoNotDisturb(false),
     mIsRejectTeleportOffers(false),
     mIgnorePrejump(FALSE),
@@ -539,6 +542,9 @@ void LLAgent::init()
     setRejectTeleportOffers(gSavedPerAccountSettings.getBOOL("ALRejectTeleportOffersMode"));
     setAutoRespond(gSavedPerAccountSettings.getBOOL("AutoRespondModeSet"));
     setAutoRespondNonFriends(gSavedPerAccountSettings.getBOOL("AutoRespondNonFriendsModeSet"));
+
+    setRejectingConferences(gSavedPerAccountSettings.getBOOL("AlchemyIgnoreAdHocSessions"));
+    setAllowConferenceFromFriends(gSavedPerAccountSettings.getBOOL("AlchemyDontIgnoreAdHocFromFriends"));
 
 
     if (!mTeleportFinishedSlot.connected())
@@ -1839,6 +1845,42 @@ void LLAgent::setAutoRespondNonFriends(bool pIsAutoRespondNonFriends)
 bool LLAgent::getAutoRespondNonFriends() const
 {
     return mIsAutoRespondNonFriends;
+}
+
+//-----------------------------------------------------------------------------
+// setRejectingConferences()
+//-----------------------------------------------------------------------------
+void LLAgent::setRejectingConferences(bool pIsRejectingConferences)
+{
+    LL_INFOS() << "Setting reject adhoc mode to " << pIsRejectingConferences << LL_ENDL;
+    mIsRejectingConferences = pIsRejectingConferences;
+    gSavedPerAccountSettings.setBOOL("AlchemyIgnoreAdHocSessions", pIsRejectingConferences);
+}
+
+//-----------------------------------------------------------------------------
+// isRejectingConferences()
+//-----------------------------------------------------------------------------
+bool LLAgent::isRejectingConferences()
+{
+    return mIsRejectingConferences;
+}
+
+//-----------------------------------------------------------------------------
+// setAllowConferenceFromFriends()
+//-----------------------------------------------------------------------------
+void LLAgent::setAllowConferenceFromFriends(bool pIsRejectingConferencesFriends)
+{
+    LL_INFOS() << "Setting reject adhoc mode to " << pIsRejectingConferencesFriends << LL_ENDL;
+    mIsAllowingConferenceFromFriends = pIsRejectingConferencesFriends;
+    gSavedPerAccountSettings.setBOOL("AlchemyDontIgnoreAdHocFromFriends", pIsRejectingConferencesFriends);
+}
+
+//-----------------------------------------------------------------------------
+// isRejectingConferences()
+//-----------------------------------------------------------------------------
+bool LLAgent::isAllowingConferencesFromFriends()
+{
+    return mIsAllowingConferenceFromFriends;
 }
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -446,9 +446,6 @@ LLAgent::LLAgent() :
 
     mIsAutoRespond(false),
     mIsAutoRespondNonFriends(false),
-    
-    mIsRejectingConferences(false),
-    mIsAllowingConferenceFromFriends(false),
 
     mIsDoNotDisturb(false),
     mIsRejectTeleportOffers(false),
@@ -1845,42 +1842,6 @@ void LLAgent::setAutoRespondNonFriends(bool pIsAutoRespondNonFriends)
 bool LLAgent::getAutoRespondNonFriends() const
 {
     return mIsAutoRespondNonFriends;
-}
-
-//-----------------------------------------------------------------------------
-// setRejectingConferences()
-//-----------------------------------------------------------------------------
-void LLAgent::setRejectingConferences(bool pIsRejectingConferences)
-{
-    LL_INFOS() << "Setting reject adhoc mode to " << pIsRejectingConferences << LL_ENDL;
-    mIsRejectingConferences = pIsRejectingConferences;
-    gSavedPerAccountSettings.setBOOL("AlchemyIgnoreAdHocSessions", pIsRejectingConferences);
-}
-
-//-----------------------------------------------------------------------------
-// isRejectingConferences()
-//-----------------------------------------------------------------------------
-bool LLAgent::isRejectingConferences()
-{
-    return mIsRejectingConferences;
-}
-
-//-----------------------------------------------------------------------------
-// setAllowConferenceFromFriends()
-//-----------------------------------------------------------------------------
-void LLAgent::setAllowConferenceFromFriends(bool pIsRejectingConferencesFriends)
-{
-    LL_INFOS() << "Setting reject adhoc mode to " << pIsRejectingConferencesFriends << LL_ENDL;
-    mIsAllowingConferenceFromFriends = pIsRejectingConferencesFriends;
-    gSavedPerAccountSettings.setBOOL("AlchemyDontIgnoreAdHocFromFriends", pIsRejectingConferencesFriends);
-}
-
-//-----------------------------------------------------------------------------
-// isRejectingConferences()
-//-----------------------------------------------------------------------------
-bool LLAgent::isAllowingConferencesFromFriends()
-{
-    return mIsAllowingConferenceFromFriends;
 }
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -540,10 +540,6 @@ void LLAgent::init()
     setAutoRespond(gSavedPerAccountSettings.getBOOL("AutoRespondModeSet"));
     setAutoRespondNonFriends(gSavedPerAccountSettings.getBOOL("AutoRespondNonFriendsModeSet"));
 
-    setRejectingConferences(gSavedPerAccountSettings.getBOOL("AlchemyIgnoreAdHocSessions"));
-    setAllowConferenceFromFriends(gSavedPerAccountSettings.getBOOL("AlchemyDontIgnoreAdHocFromFriends"));
-
-
     if (!mTeleportFinishedSlot.connected())
     {
         mTeleportFinishedSlot = LLViewerParcelMgr::getInstance()->setTeleportFinishedCallback(boost::bind(&LLAgent::handleTeleportFinished, this));

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -513,18 +513,6 @@ public:
 private:
     BOOL            mIsAutoRespondNonFriends;
 
-public:
-    void            setRejectingConferences(bool pIsRejectingConferences);
-    bool            isRejectingConferences();
-private:
-    bool            mIsRejectingConferences;
-
-public:
-    void            setAllowConferenceFromFriends(bool pIsRejectingConferencesFriends);
-    bool            isAllowingConferencesFromFriends();
-private:
-    bool            mIsAllowingConferenceFromFriends;
-
     //--------------------------------------------------------------------
     // Grab
     //--------------------------------------------------------------------

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -513,6 +513,18 @@ public:
 private:
     BOOL            mIsAutoRespondNonFriends;
 
+public:
+    void            setRejectingConferences(bool pIsRejectingConferences);
+    bool            isRejectingConferences();
+private:
+    bool            mIsRejectingConferences;
+
+public:
+    void            setAllowConferenceFromFriends(bool pIsRejectingConferencesFriends);
+    bool            isAllowingConferencesFromFriends();
+private:
+    bool            mIsAllowingConferenceFromFriends;
+
     //--------------------------------------------------------------------
     // Grab
     //--------------------------------------------------------------------

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1069,6 +1069,13 @@ void LLFloaterPreference::apply()
     gAgent.setAutoRespond(autoresponse_enabled);
     gAgent.setAutoRespondNonFriends(autoresponse_notfriends_enabled);
 
+    // Block AdHoc conferences.
+    bool is_rejecting_conferences = getChild<LLCheckBoxCtrl>("AlchemyIgnoreAdHocSessions")->get();
+    bool is_allowing_friend_conferences = getChild<LLCheckBoxCtrl>("AlchemyDontIgnoreAdHocFromFriends")->get();
+
+    gAgent.setRejectingConferences(is_rejecting_conferences);
+    gAgent.setAllowConferenceFromFriends(is_allowing_friend_conferences);
+
     saveAvatarProperties();
 }
 

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1069,13 +1069,6 @@ void LLFloaterPreference::apply()
     gAgent.setAutoRespond(autoresponse_enabled);
     gAgent.setAutoRespondNonFriends(autoresponse_notfriends_enabled);
 
-    // Block AdHoc conferences.
-    bool is_rejecting_conferences = getChild<LLCheckBoxCtrl>("AlchemyIgnoreAdHocSessions")->get();
-    bool is_allowing_friend_conferences = getChild<LLCheckBoxCtrl>("AlchemyDontIgnoreAdHocFromFriends")->get();
-
-    gAgent.setRejectingConferences(is_rejecting_conferences);
-    gAgent.setAllowConferenceFromFriends(is_allowing_friend_conferences);
-
     saveAvatarProperties();
 }
 
@@ -3885,4 +3878,10 @@ void LLFloaterPreference::restoreIgnoredNotifications()
     {
         LLUI::getInstance()->mSettingGroups["ignores"]->setBOOL(it->first, it->second);
     }
+}
+
+void LLFloaterPreference::onAdHocSelectionChange(const LLSD& newvalue)
+{
+    S32 value = gSavedPerAccountSettings.getS32("AlchemyIgnoreAdHocSessions");
+    getChild<LLCheckBoxCtrl>("AlchemyReportIgnoredAdHocSession")->setEnabled(value != 0);
 }

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -128,6 +128,9 @@ protected:
     void onAutoRespondResponseChanged();
     void onAutoRespondNonFriendsResponseChanged();
 
+    // This is used to control the enabling / disabling of the checkbox as the `enable_control="AlchemyIgnoreAdHocSessions"` is not boolean
+    void onAdHocSelectionChange(const LLSD& newValue);
+
     // if the custom settings box is clicked
     void onChangeCustom();
     void updateMeterText(LLUICtrl* ctrl);

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3283,8 +3283,8 @@ void LLIMMgr::addMessage(
                 }
             }
 
-            bool is_rejecting_conferences = gAgent.isRejectingConferences();
-            bool is_allowing_friend_conferences = gAgent.isAllowingConferencesFromFriends();
+            S32 is_rejecting_conferences = gSavedPerAccountSettings.getS32("AlchemyIgnoreAdHocSessions");
+            bool is_allowing_friend_conferences = (is_rejecting_conferences == 1);
             bool is_friend = LLAvatarTracker::instance().isBuddy(other_participant_id);
             is_group_chat = session->isGroupSessionType();
 

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3302,7 +3302,7 @@ void LLIMMgr::addMessage(
                     }
                     else if (report_ignored_conferences)
                     {
-                        addSystemMessage(LLUUID::null, "IgnoredAdHocSession",args);
+                        LLNotificationsUtil::add("IgnoredAdHocSession", args);
                     }
 
                     return;

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -64,6 +64,7 @@
 #include "llnotifications.h"
 #include "llnotificationsutil.h"
 #include "llfloaterimnearbychat.h"
+#include "llslurl.h"
 #include "llspeakers.h" //for LLIMSpeakerMgr
 #include "lltextbox.h"
 #include "lltoolbarview.h"
@@ -3201,6 +3202,7 @@ void LLIMMgr::addMessage(
         fixed_session_name = session_name;
         name_is_setted = true;
     }
+    bool is_group_chat = false;
     bool skip_message = false;
     bool from_linden = LLMuteList::isLinden(from);
     if (gSavedPerAccountSettings.getBOOL("VoiceCallsFriendsOnly") && !from_linden &&
@@ -3278,6 +3280,32 @@ void LLIMMgr::addMessage(
                 if (!chat_url.empty())
                 {
                     LLCoros::instance().launch("chatterBoxHistoryCoro", boost::bind(&chatterBoxHistoryCoro, chat_url, session_id, from, msg, timestamp));
+                }
+            }
+
+            bool is_rejecting_conferences = gAgent.isRejectingConferences();
+            bool is_allowing_friend_conferences = gAgent.isAllowingConferencesFromFriends();
+            bool is_friend = LLAvatarTracker::instance().isBuddy(other_participant_id);
+            is_group_chat = session->isGroupSessionType();
+
+            if (IM_NOTHING_SPECIAL != dialog && !is_group_chat && is_rejecting_conferences && !from_linden)
+            {
+                if (!is_allowing_friend_conferences || (is_allowing_friend_conferences && !is_friend))
+                {
+                    bool report_ignored_conferences = gSavedPerAccountSettings.getBool("AlchemyReportIgnoredAdHocSession");
+                    LLSD args;
+                    args["AVATAR_NAME"] = LLSLURL("agent", other_participant_id, "about").getSLURLString();
+                    LL_INFOS() << "Ignoring conference (ad-hoc) chat from " << args["AVATAR_NAME"] << LL_ENDL;
+                    if (!gIMMgr->leaveSession(new_session_id))
+                    {
+                        LL_WARNS() << "Ad-hoc session " << new_session_id << " doesn't exist" << LL_ENDL;
+                    }
+                    else if (report_ignored_conferences)
+                    {
+                        addSystemMessage(LLUUID::null, "IgnoredAdHocSession",args);
+                    }
+
+                    return;
                 }
             }
 

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -13356,4 +13356,10 @@ Incoming instant messages from anyone who is not your friend will now be answere
      name="okignore"
      yestext="OK"/>
   </notification>
+  <notification
+     icon="notifytip.tga"
+     name="IgnoredAdHocSession"
+     type="notifytip">
+You've been invited to a conference (ad-hoc) chat by [AVATAR_NAME], but the viewer automatically ignored it because of your settings.
+  </notification>
 </notifications>

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
@@ -70,4 +70,31 @@
           name="ALDontRejectTeleportOffersFromFriends"
           width="500"
           control_name="ALDontRejectTeleportOffersFromFriends" />
+          <check_box
+             layout="topleft"
+             follows="left|top"
+             top_pad="5"
+             height="18"
+             name="AlchemyIgnoreAdHocSessions"
+             control_name="AlchemyIgnoreAdHocSessions"
+             label="Automatically ignore and leave all conference (ad-hoc) chats"/>
+            <check_box
+             layout="topleft"
+             follows="left|top"
+             left_delta="10"
+             enabled_control="AlchemyIgnoreAdHocSessions"
+             top_pad="5"
+             height="18"
+             name="AlchemyReportIgnoredAdHocSession"
+             control_name="AlchemyReportIgnoredAdHocSession"
+             label="Report ignored conference chats in nearby chat"/>
+            <check_box
+             layout="topleft"
+             follows="left|top"
+             enabled_control="AlchemyIgnoreAdHocSessions"
+             top_pad="5"
+             height="18"
+             name="AlchemyDontIgnoreAdHocFromFriends"
+             control_name="AlchemyDontIgnoreAdHocFromFriends"
+             label="Don't ignore conference chats invitations from my friends"/>
     </panel>

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
@@ -70,31 +70,45 @@
           name="ALDontRejectTeleportOffersFromFriends"
           width="500"
           control_name="ALDontRejectTeleportOffersFromFriends" />
+                     <text
+        top_pad="15"
+        follows="left|top"
+        height="18"
+        type="string"
+        length="1"
+        layout="topleft"
+        left="15"
+        name="adhoc_ignore_label"
+        mouse_opaque="false"
+        width="500">
+        Reject Ad-Hoc (conferences):
+        </text>
+        <combo_box
+          control_name="AlchemyIgnoreAdHocSessions"
+          follows="left|top"
+          layout="topleft"
+          height="23"
+          name="adhoc_preference_combo"
+          width="115">
+          <item
+            label="Off"
+            name="adhoc_preference_allow_none"
+            value="0"/>
+          <item
+            label="Friends Only"
+            name="adhoc_preference_allow_friends"
+            value="1"/>
+          <item
+            label="All"
+            name="adhoc_preference_allow_all"
+            value="2"/>
+          </combo_box>
           <check_box
-             layout="topleft"
-             follows="left|top"
-             top_pad="5"
-             height="18"
-             name="AlchemyIgnoreAdHocSessions"
-             control_name="AlchemyIgnoreAdHocSessions"
-             label="Automatically ignore and leave all conference (ad-hoc) chats"/>
-            <check_box
-             layout="topleft"
-             follows="left|top"
-             left_delta="10"
-             enabled_control="AlchemyIgnoreAdHocSessions"
-             top_pad="5"
-             height="18"
-             name="AlchemyReportIgnoredAdHocSession"
-             control_name="AlchemyReportIgnoredAdHocSession"
-             label="Report ignored conference chats in nearby chat"/>
-            <check_box
-             layout="topleft"
-             follows="left|top"
-             enabled_control="AlchemyIgnoreAdHocSessions"
-             top_pad="5"
-             height="18"
-             name="AlchemyDontIgnoreAdHocFromFriends"
-             control_name="AlchemyDontIgnoreAdHocFromFriends"
-             label="Don't ignore conference chats invitations from my friends"/>
+            layout="topleft"
+            follows="left|top"
+            left_delta="125"
+            height="18"
+            name="AlchemyReportIgnoredAdHocSession"
+            control_name="AlchemyReportIgnoredAdHocSession"
+            label="Report ignored conference chats in nearby chat"/>
     </panel>

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
@@ -110,5 +110,5 @@
             height="18"
             name="AlchemyReportIgnoredAdHocSession"
             control_name="AlchemyReportIgnoredAdHocSession"
-            label="Report ignored conference chats in nearby chat"/>
+            label="Report ignored conference chats"/>
     </panel>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -4576,4 +4576,5 @@ and report the problem.
     </string>
 	<string name="AutoResponseModeDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
 	<string name="AutoResponseModeNonFriendsDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
+    <string name="IgnoredAdHocSession">You've been invited to a conference (ad-hoc) chat by [AVATAR_NAME], but the viewer automatically ignored it because of your settings.</string>
 </strings>


### PR DESCRIPTION
This PR is to address an annoyance where users automatically add you to a conference.
As a result, I've added the option to automatically leave the conference (adhoc), and announce (if requested). 
Idea came from the very talented Firestorm folks so I appreciate their take on this. ~I've bound the event on `llagent`.~

*Known Issues / Caveats
None that I'm aware of