### PR TITLE
Fix calling texture filtering/address mode Fast calls with invalid tex type

### DIFF
--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -210,8 +210,8 @@ void LLTexUnit::bindFast(LLTexture* texture)
     if (gl_tex->mTexOptionsDirty)
     {
         gl_tex->mTexOptionsDirty = false;
-        setTextureAddressModeFast(gl_tex->mAddressMode);
-        setTextureFilteringOptionFast(gl_tex->mFilterOption);
+        setTextureAddressModeFast(gl_tex->mAddressMode, gl_tex->getTarget());
+        setTextureFilteringOptionFast(gl_tex->mFilterOption, gl_tex->getTarget());
     }
 }
 
@@ -467,16 +467,16 @@ void LLTexUnit::setTextureAddressMode(eTextureAddressMode mode)
 
     activate();
 
-    setTextureAddressModeFast(mode);
+    setTextureAddressModeFast(mode, mCurrTexType);
 }
 
-void LLTexUnit::setTextureAddressModeFast(eTextureAddressMode mode)
+void LLTexUnit::setTextureAddressModeFast(eTextureAddressMode mode, eTextureType tex_type)
 {
-    glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_WRAP_S, sGLAddressMode[mode]);
-    glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_WRAP_T, sGLAddressMode[mode]);
-    if (mCurrTexType == TT_CUBE_MAP || mCurrTexType == TT_CUBE_MAP_ARRAY || mCurrTexType == TT_TEXTURE_3D)
+    glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_WRAP_S, sGLAddressMode[mode]);
+    glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_WRAP_T, sGLAddressMode[mode]);
+    if (tex_type == TT_CUBE_MAP || tex_type == TT_CUBE_MAP_ARRAY || tex_type == TT_TEXTURE_3D)
     {
-        glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_WRAP_R, sGLAddressMode[mode]);
+        glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_WRAP_R, sGLAddressMode[mode]);
     }
 }
 
@@ -486,44 +486,44 @@ void LLTexUnit::setTextureFilteringOption(LLTexUnit::eTextureFilterOptions optio
 
     gGL.flush();
 
-    setTextureFilteringOptionFast(option);
+    setTextureFilteringOptionFast(option, mCurrTexType);
 }
 
-void LLTexUnit::setTextureFilteringOptionFast(LLTexUnit::eTextureFilterOptions option)
+void LLTexUnit::setTextureFilteringOptionFast(LLTexUnit::eTextureFilterOptions option, eTextureType tex_type)
 {
     if (option == TFO_POINT)
     {
-        glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     }
     else
     {
-        glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     }
 
     if (option >= TFO_TRILINEAR && mHasMipMaps)
     {
-        glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+        glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     }
     else if (option >= TFO_BILINEAR)
     {
         if (mHasMipMaps)
         {
-            glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
+            glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
         }
         else
         {
-            glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+            glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         }
     }
     else
     {
         if (mHasMipMaps)
         {
-            glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+            glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
         }
         else
         {
-            glTexParameteri(sGLTextureType[mCurrTexType], GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(sGLTextureType[tex_type], GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         }
     }
 
@@ -531,11 +531,11 @@ void LLTexUnit::setTextureFilteringOptionFast(LLTexUnit::eTextureFilterOptions o
     {
         if (LLImageGL::sGlobalUseAnisotropic && option == TFO_ANISOTROPIC)
         {
-            glTexParameterf(sGLTextureType[mCurrTexType], GL_TEXTURE_MAX_ANISOTROPY, gGLManager.mMaxAnisotropy);
+            glTexParameterf(sGLTextureType[tex_type], GL_TEXTURE_MAX_ANISOTROPY, gGLManager.mMaxAnisotropy);
         }
         else
         {
-            glTexParameterf(sGLTextureType[mCurrTexType], GL_TEXTURE_MAX_ANISOTROPY, 1.f);
+            glTexParameterf(sGLTextureType[tex_type], GL_TEXTURE_MAX_ANISOTROPY, 1.f);
         }
     }
 }

--- a/indra/llrender/llrender.h
+++ b/indra/llrender/llrender.h
@@ -209,14 +209,14 @@ public:
     // make sure you want to permanently change the address mode  for the bound texture.
     void setTextureAddressMode(eTextureAddressMode mode);
     // MUST already be active and bound
-    void setTextureAddressModeFast(eTextureAddressMode mode);
+    void setTextureAddressModeFast(eTextureAddressMode mode, eTextureType tex_type);
 
     // Sets the filtering options used to sample the texture
     // Warning: this stays set for the bound texture forever,
     // make sure you want to permanently change the filtering for the bound texture.
     void setTextureFilteringOption(LLTexUnit::eTextureFilterOptions option);
     // MUST already be active and bound
-    void setTextureFilteringOptionFast(LLTexUnit::eTextureFilterOptions option);
+    void setTextureFilteringOptionFast(LLTexUnit::eTextureFilterOptions option, eTextureType tex_type);
 
     static U32 getInternalType(eTextureType type);
 


### PR DESCRIPTION
This affected fast binds and kinda broke cubemaps among other things