### PR TITLE
Improve install.sh

### DIFF
--- a/indra/newview/linux_tools/install.sh
+++ b/indra/newview/linux_tools/install.sh
@@ -41,7 +41,7 @@ function die()
 function warn()
 {
     echo -n "$_COLOR_RED"
-    echo "$1"
+    echo -e "$1"
     echo -n "$_STYLE_NORMAL"
 }
 
@@ -82,7 +82,9 @@ function root_install()
 
 function install_to_prefix()
 {
-    test -e "$1" && backup_previous_installation "$1"
+    if [[ -e "$1" && -z $NOBACKUP ]]; then
+        backup_previous_installation "$1"
+    fi
     mkdir -p "$1" || die "Failed to create installation directory!"
 
     echo " - Installing to $1"
@@ -95,7 +97,7 @@ function backup_previous_installation()
     local backup_dir="$1".backup-$(date -I)
     echo " - Backing up previous installation to $backup_dir"
 
-    mv "$1" "$backup_dir" || die "Failed to create backup of existing installation!"
+    mv "$1" "$backup_dir" || die "Failed to create backup of existing installation!\nSpecify NOBACKUP=1 when invoking to skip the backup step."
 }
 
 

--- a/indra/newview/linux_tools/install.sh
+++ b/indra/newview/linux_tools/install.sh
@@ -3,8 +3,12 @@
 # Install the Second Life Viewer. This script can install the viewer both
 # system-wide and for an individual user.
 
-_STYLE_NORMAL="$(tput sgr0)"
-_COLOR_RED="$(tput setaf 9)"
+exec 3>&2 2> /dev/null
+if command -v tput > /dev/null ; then
+    _STYLE_NORMAL="$(tput sgr0)"
+    _COLOR_RED="$(tput setaf 9)"
+fi
+exec 2>&3 3>&-
 
 SCRIPTSRC=`readlink -f "$0" || echo "$0"`
 RUN_PATH=`dirname "${SCRIPTSRC}" || echo .`

--- a/indra/newview/linux_tools/install.sh
+++ b/indra/newview/linux_tools/install.sh
@@ -3,8 +3,8 @@
 # Install the Second Life Viewer. This script can install the viewer both
 # system-wide and for an individual user.
 
-VT102_STYLE_NORMAL='\E[0m'
-VT102_COLOR_RED='\E[31m'
+_STYLE_NORMAL="$(tput sgr0)"
+_COLOR_RED="$(tput setaf 9)"
 
 SCRIPTSRC=`readlink -f "$0" || echo "$0"`
 RUN_PATH=`dirname "${SCRIPTSRC}" || echo .`
@@ -34,15 +34,15 @@ function prompt()
 
 function die()
 {
-    warn $1
+    warn "$1"
     exit 1
 }
 
 function warn()
 {
-    echo -n -e $VT102_COLOR_RED
-    echo $1
-    echo -n -e $VT102_STYLE_NORMAL
+    echo -n "$_COLOR_RED"
+    echo "$1"
+    echo -n "$_STYLE_NORMAL"
 }
 
 function homedir_install()


### PR DESCRIPTION
## Description

Two issues with the current `install.sh` for Linux:

1. The `die` and `warn` functions chop the string to only its first word
2. There is no way to skip the backup step; doing backup using `mv` results in failure if the installation directory is mounted on a separate filesystem.

This PR provides 2 things:

1. Fixing the output of error message
2. Option to skip backup

## Related Issues

No related issue that I know of.

---

## Checklist

Please ensure the following before requesting review:

- [X] I have provided a clear title and detailed description for this pull request.
- [X] If useful, I have included media such as screenshots and video to show off my changes.
- [X] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [X] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

Skipping of backup process is done like so:

```sh
NOBACKUP=1 ./install.sh
```

or if installing using `sudo`:

```sh
NOBACKUP=1 sudo --preserve-env=NOBACKUP ./install.sh
```