### PR TITLE
Re-enable macos x64 builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -221,6 +221,14 @@ jobs:
           sudo locale-gen en_GB.UTF-8
           sudo locale-gen fr_FR.UTF-8
 
+          df -h
+          sudo docker container prune -f
+          sudo docker image prune -a -f
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          df -h
+
       - name: macOS Homebrew Dependency Install
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -152,8 +152,6 @@ jobs:
             configuration: relwithdebinfo
           - runner: macos-26
             configuration: optdebug
-          - runner: macos-26
-            arch: x64
 
     runs-on: ${{ matrix.runner }}
     outputs:


### PR DESCRIPTION
## Description

Enable macOS x86_64 builds again.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
