### PR TITLE
Always render world viewer rect at full window size.

### DIFF
--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -4327,6 +4327,9 @@ void LLViewerWindow::updateWorldViewRect(bool use_full_window)
     // start off using whole window to render world
     LLRect new_world_rect = mWindowRectRaw;
 
+#if 0 // Disable dynamic world view resizing for now since it causes some peformance issues on large displays when entering/leaving
+      // mouselook or hiding UI. We can re-enable this in the future when we have a better solution for the performance issues, such as
+      // rendering to a smaller offscreen buffer and then upscaling to the window size.
     if (!use_full_window && mWorldViewPlaceholder.get())
     {
         new_world_rect = mWorldViewPlaceholder.get()->calcScreenRect();
@@ -4339,6 +4342,7 @@ void LLViewerWindow::updateWorldViewRect(bool use_full_window)
         new_world_rect.mBottom = ll_round((F32)new_world_rect.mBottom * mDisplayScale.mV[VY]);
         new_world_rect.mTop = ll_round((F32)new_world_rect.mTop * mDisplayScale.mV[VY]);
     }
+#endif
 
     if (mWorldViewRectRaw != new_world_rect)
     {


### PR DESCRIPTION
## Description

Transitions to/from mouselook on extreme resolution displays was resulting in window buffers repeatedly being torn down and recreated.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
