### PR TITLE
Updates build dependencies for Arch, Debian, and Ubuntu for david

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -72,7 +72,7 @@ Install system packages for your distro:
 ```
 sudo pacman -Syu automake autoconf autoconf-archive base-devel cmake fontconfig git glib2-devel \
     gstreamer gst-plugins-base-libs ninja libglvnd libtool libvlc libx11 pkgconf python \
-    wayland dotnet-sdk rustup zip
+    wayland dotnet-sdk rustup zip nasm
 ```
 
 </details>

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -90,7 +90,7 @@ sudo apt install \
     libthai-dev libtool libudev-dev libunwind-dev liburing-dev libvlc-dev libwayland-dev \
     libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev \
     libxkbcommon-dev libxrandr-dev libxss-dev libxtst-dev linux-libc-dev ninja-build \
-    pkgconf tar tex-common texinfo unzip zip dotnet-sdk-10.0 rustup
+    pkgconf tar tex-common texinfo unzip zip dotnet-sdk-10.0 rustup nasm
 ```
 
 </details>
@@ -108,7 +108,7 @@ sudo apt install \
     libthai-dev libtool libudev-dev libunwind-dev liburing-dev libvlc-dev libwayland-dev \
     libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev \
     libxkbcommon-dev libxrandr-dev libxss-dev libxtst-dev linux-libc-dev ninja-build \
-    pkgconf tar tex-common texinfo unzip zip dotnet-sdk-10.0 rustup
+    pkgconf tar tex-common texinfo unzip zip dotnet-sdk-10.0 rustup nasm
 ```
 
 </details>


### PR DESCRIPTION
## Description

Build failed in Arch before installing "nasm", as seen recently listed as a build requirement for Fedora. The error message implied Debian-based distros also require this.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

I'm uncertain what other distros may also require this, we'll have to verify.

Error message caused when lacking nasm: 
```
CMake Error at scripts/cmake/vcpkg_find_acquire_program.cmake:201 (message):
  Could not find nasm.  Please install it via your package manager:

      sudo apt-get install nasm
Call Stack (most recent call first):
  buildtrees/versioning_/versions/dav1d/645d003a191d193f63024a74b6faedb2cb238a51/portfile.cmake:10 (vcpkg_find_acquire_program)
  scripts/ports.cmake:206 (include)


error: building dav1d:x64-linux-secondlife failed with: BUILD_FAILED
See https://learn.microsoft.com/vcpkg/troubleshoot/build-failures?WT.mc_id=vcpkg_inproduct_cli for more information.
Elapsed time to handle dav1d:x64-linux-secondlife: 111 ms
Please ensure you're using the latest port files with `git pull` and `vcpkg update`.
Then check for known issues at:
  https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+dav1d
You can submit a new issue at:
  https://github.com/microsoft/vcpkg/issues/new?title=%5Bdav1d%5D%20build%20error%20on%20x64-linux-secondlife&body=Copy%20issue%20body%20from%20%2Fhome%2Fuser%2FGitHub%2FGalaxyLittlepaws%2FAlchemy%2Fbuild-Linux-ninja-os%2Fvcpkg_installed%2Fvcpkg%2Fissue_body.md

-- Running vcpkg install - failed
CMake Error at /home/user/GitHub/GalaxyLittlepaws/Alchemy/vcpkg/scripts/buildsystems/vcpkg.cmake:955 (message):
  vcpkg install failed.  See logs for more information:
  /home/user/GitHub/GalaxyLittlepaws/Alchemy/build-Linux-ninja-os/vcpkg-manifest-install.log
Call Stack (most recent call first):
  /usr/share/cmake/Modules/CMakeDetermineSystem.cmake:146 (include)
  CMakeLists.txt:194 (project)


CMake Error: CMake was unable to find a build program corresponding to "Ninja Multi-Config".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
```