### PR TITLE
Add opt-in SDL3 window backend for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ indra/lib/python/eventlet/
 indra/lib/python/mulib.*
 indra/llwindow/glh/glh_linear.h
 indra/newview/alchemy.icns
+indra/newview/app_settings/alchemy_logo.png
 indra/newview/app_settings/dictionaries
 indra/newview/app_settings/mozilla
 indra/newview/app_settings/mozilla-runtime-*

--- a/indra/CMakeLists.txt
+++ b/indra/CMakeLists.txt
@@ -70,7 +70,11 @@ option(HAVOK "Use Havok physics library" OFF)
 #cmake_dependent_option(USE_DISCORD "Enable Discord SDK and Rich Prescence support" ON "INSTALL_PROPRIETARY" OFF)
 
 # SDL Options
-cmake_dependent_option(USE_SDL_WINDOW "Build with SDL based window management and input" ON "UNIX" OFF)
+if (UNIX)
+  option(USE_SDL_WINDOW "Build with SDL based window management and input" ON)
+else ()
+  option(USE_SDL_WINDOW "Build with SDL based window management and input (experimental on Windows)" OFF)
+endif ()
 
 # Configure crash reporting
 option(RELEASE_CRASH_REPORTING "Enable use of crash reporting in release builds" OFF)

--- a/indra/CMakePresets.json
+++ b/indra/CMakePresets.json
@@ -106,6 +106,16 @@
       ]
     },
     {
+      "name": "vs2026-os-sdl",
+      "displayName": "Visual Studio 2026 (SDL window)",
+      "inherits": [
+        "vs2026-os"
+      ],
+      "cacheVariables": {
+        "USE_SDL_WINDOW": true
+      }
+    },
+    {
       "name": "ninja-os-arm64",
       "displayName": "Ninja Multi-Config(arm64)",
       "inherits": [
@@ -334,6 +344,22 @@
     {
       "name": "vs2026-os-release",
       "configurePreset": "vs2026-os",
+      "configuration": "Release",
+      "inherits": [
+        "windows"
+      ]
+    },
+    {
+      "name": "vs2026-os-sdl-relwithdebinfo",
+      "configurePreset": "vs2026-os-sdl",
+      "configuration": "RelWithDebInfo",
+      "inherits": [
+        "windows"
+      ]
+    },
+    {
+      "name": "vs2026-os-sdl-release",
+      "configurePreset": "vs2026-os-sdl",
       "configuration": "Release",
       "inherits": [
         "windows"

--- a/indra/cmake/Linking.cmake
+++ b/indra/cmake/Linking.cmake
@@ -37,6 +37,7 @@ elseif (WINDOWS)
           advapi32
           shlwapi
           shell32
+          wbemuuid
           ws2_32
           mswsock
           psapi

--- a/indra/cmake/SDL3.cmake
+++ b/indra/cmake/SDL3.cmake
@@ -9,7 +9,10 @@ endif()
 find_package(SDL3 CONFIG REQUIRED)
 target_link_libraries(ll::SDL3 INTERFACE SDL3::SDL3)
 
-if(DARWIN)
-  find_package(SDL3_image CONFIG REQUIRED)
-  target_link_libraries(ll::SDL3 INTERFACE $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image::SDL3_image-static>)
-endif()
+# SDL3_ttf renders the LLWindowSDL splash-screen text (see LLSplashScreenSDL).
+find_package(SDL3_ttf CONFIG REQUIRED)
+target_link_libraries(ll::SDL3 INTERFACE $<IF:$<TARGET_EXISTS:SDL3_ttf::SDL3_ttf-shared>,SDL3_ttf::SDL3_ttf-shared,SDL3_ttf::SDL3_ttf-static>)
+
+# SDL3_image loads the branded splash icon PNG (and, on macOS, the cursor TIFFs).
+find_package(SDL3_image CONFIG REQUIRED)
+target_link_libraries(ll::SDL3 INTERFACE $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image::SDL3_image-static>)

--- a/indra/cmake/UI.cmake
+++ b/indra/cmake/UI.cmake
@@ -51,6 +51,7 @@ elseif(WINDOWS)
           odbccp32
           oleaut32
           shell32
+          shlwapi
           Vfw32
           wer
           winspool

--- a/indra/llrender/CMakeLists.txt
+++ b/indra/llrender/CMakeLists.txt
@@ -105,7 +105,10 @@ target_link_libraries(llrender
 
 target_precompile_headers(llrender REUSE_FROM llprecompiled)
 
-if (DARWIN OR NOT USE_SDL_WINDOW)
+# llgl.cpp talks to WGL directly on Windows (wglGetCurrentDC for the
+# extensions string) even when SDL owns context creation, so keep the
+# OpenGL link explicit there regardless of the window backend.
+if (DARWIN OR WINDOWS OR NOT USE_SDL_WINDOW)
   target_link_libraries(llrender
           OpenGL::GL
           )

--- a/indra/llui/fsvirtualtrackpad.cpp
+++ b/indra/llui/fsvirtualtrackpad.cpp
@@ -597,7 +597,7 @@ bool FSVirtualTrackpad::handleRightMouseDown(S32 x, S32 y, MASK mask)
 }
 
 // pass wheel-clicks to third axis
-bool FSVirtualTrackpad::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool FSVirtualTrackpad::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (hasMouseCapture() || isPointInTouchArea(x, y))
     {
@@ -607,7 +607,7 @@ bool FSVirtualTrackpad::handleScrollWheel(S32 x, S32 y, S32 clicks)
         if (mask & MASK_CONTROL)
             changeAmount /= 5;
 
-        mWheelClicksSinceLastDelta = -1 * clicks * changeAmount;
+        mWheelClicksSinceLastDelta = -1 * delta.mClicks * changeAmount;
 
         mValueDeltaX = mValueDeltaY = mValueDeltaZ = 0;
         mPinchValueDeltaX = mPinchValueDeltaY = mPinchValueDeltaZ = 0;
@@ -655,5 +655,5 @@ bool FSVirtualTrackpad::handleScrollWheel(S32 x, S32 y, S32 clicks)
         return true;
     }
     else
-        return LLUICtrl::handleScrollWheel(x, y, clicks);
+        return LLUICtrl::handleScrollWheel(x, y, delta);
 }

--- a/indra/llui/fsvirtualtrackpad.h
+++ b/indra/llui/fsvirtualtrackpad.h
@@ -55,7 +55,7 @@ public:
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleRightMouseUp(S32 x, S32 y, MASK mask) override;
     bool handleRightMouseDown(S32 x, S32 y, MASK mask) override;
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
     void draw() override;
     void setValue(const LLSD& value) override;
 

--- a/indra/llui/llaccordionctrl.cpp
+++ b/indra/llui/llaccordionctrl.cpp
@@ -536,11 +536,11 @@ void LLAccordionCtrl::arrange()
 
 //---------------------------------------------------------------------------------
 
-bool LLAccordionCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLAccordionCtrl::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    if (LLPanel::handleScrollWheel(x, y, clicks))
+    if (LLPanel::handleScrollWheel(x, y, delta))
         return true;
-    if (mScrollbar->getVisible() && mScrollbar->handleScrollWheel(0, 0, clicks))
+    if (mScrollbar->getVisible() && mScrollbar->handleScrollWheel(0, 0, delta))
         return true;
     return false;
 }

--- a/indra/llui/llaccordionctrl.h
+++ b/indra/llui/llaccordionctrl.h
@@ -91,7 +91,7 @@ public:
     virtual bool postBuild();
 
     virtual bool handleRightMouseDown   ( S32 x, S32 y, MASK mask);
-    virtual bool handleScrollWheel      ( S32 x, S32 y, S32 clicks );
+    virtual bool handleScrollWheel      ( S32 x, S32 y, LLScrollDelta delta );
     virtual bool handleKeyHere          (KEY key, MASK mask);
     virtual bool handleDragAndDrop      (S32 x, S32 y, MASK mask, bool drop,
                                          EDragAndDropType cargo_type,

--- a/indra/llui/llaccordionctrltab.cpp
+++ b/indra/llui/llaccordionctrltab.cpp
@@ -1150,14 +1150,14 @@ bool LLAccordionCtrlTab::handleToolTip(S32 x, S32 y, MASK mask)
     return LLUICtrl::handleToolTip(x, y, mask);
 }
 
-bool LLAccordionCtrlTab::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLAccordionCtrlTab::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    if (LLUICtrl::handleScrollWheel(x, y, clicks))
+    if (LLUICtrl::handleScrollWheel(x, y, delta))
     {
         return true;
     }
 
-    if (mScrollbar && mScrollbar->getVisible() && mScrollbar->handleScrollWheel(0, 0, clicks))
+    if (mScrollbar && mScrollbar->getVisible() && mScrollbar->handleScrollWheel(0, 0, delta))
     {
         return true;
     }

--- a/indra/llui/llaccordionctrltab.h
+++ b/indra/llui/llaccordionctrltab.h
@@ -168,7 +168,7 @@ public:
     virtual bool handleKey(KEY key, MASK mask, bool called_from_parent);
 
     virtual bool handleToolTip(S32 x, S32 y, MASK mask);
-    virtual bool handleScrollWheel( S32 x, S32 y, S32 clicks );
+    virtual bool handleScrollWheel( S32 x, S32 y, LLScrollDelta delta );
 
 
     virtual bool addChild(LLView* child, S32 tab_group = 0 );

--- a/indra/llui/llcombobox.cpp
+++ b/indra/llui/llcombobox.cpp
@@ -951,11 +951,11 @@ bool LLComboBox::handleUnicodeCharHere(llwchar uni_char)
 }
 
 // virtual
-bool LLComboBox::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLComboBox::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mList->getVisible())
     {
-        return mList->handleScrollWheel(x, y, clicks);
+        return mList->handleScrollWheel(x, y, delta);
     }
 
     if (mAllowTextEntry) // We might be editable
@@ -967,9 +967,9 @@ bool LLComboBox::handleScrollWheel(S32 x, S32 y, S32 clicks)
     }
 
     S32 current_index = getCurrentIndex();
-    if (clicks > 0)
+    if (delta.mClicks > 0)
     {
-        for (S32 i = 0; i < clicks; ++i)
+        for (S32 i = 0; i < delta.mClicks; ++i)
         {
             if (!selectNextItem())
                 break;
@@ -977,7 +977,7 @@ bool LLComboBox::handleScrollWheel(S32 x, S32 y, S32 clicks)
     }
     else
     {
-        for (S32 i = 0; i < -clicks; ++i)
+        for (S32 i = 0; i < -delta.mClicks; ++i)
         {
             if (!selectPrevItem())
                 break;

--- a/indra/llui/llcombobox.h
+++ b/indra/llui/llcombobox.h
@@ -113,7 +113,7 @@ public:
     virtual bool    handleToolTip(S32 x, S32 y, MASK mask);
     virtual bool    handleKeyHere(KEY key, MASK mask);
     virtual bool    handleUnicodeCharHere(llwchar uni_char);
-    virtual bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
+    virtual bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
 
     // LLUICtrl interface
     virtual void    clear();                    // select nothing

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -1780,9 +1780,9 @@ bool LLFloater::offerClickToButton(S32 x, S32 y, MASK mask, EFloaterButton index
     return false;
 }
 
-bool LLFloater::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloater::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    LLPanel::handleScrollWheel(x,y,clicks);
+    LLPanel::handleScrollWheel(x,y,delta);
     return true;//always
 }
 

--- a/indra/llui/llfloater.h
+++ b/indra/llui/llfloater.h
@@ -329,7 +329,7 @@ public:
     virtual bool    handleDoubleClick(S32 x, S32 y, MASK mask);
     virtual bool    handleMiddleMouseDown(S32 x, S32 y, MASK mask);
 
-    virtual bool    handleScrollWheel(S32 x, S32 y, S32 mask);
+    virtual bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
 
     virtual void    draw();
     virtual void    drawShadow(LLPanel* panel);

--- a/indra/llui/llflyoutbutton.cpp
+++ b/indra/llui/llflyoutbutton.cpp
@@ -76,9 +76,9 @@ void LLFlyoutButton::draw()
     LLComboBox::draw();
 }
 
-bool LLFlyoutButton::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFlyoutButton::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return LLUICtrl::handleScrollWheel(x, y, clicks);
+    return LLUICtrl::handleScrollWheel(x, y, delta);
 }
 
 // [SL:KB] - Patch: Control-FlyoutButton | Checked: Catznip-6.4

--- a/indra/llui/llflyoutbutton.h
+++ b/indra/llui/llflyoutbutton.h
@@ -62,7 +62,7 @@ protected:
 public:
     void draw() override;
 
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
 
 // [SL:KB] - Patch: Control-FlyoutButton | Checked: Catznip-6.4
     void    setLabel(const LLStringExplicit& name) override;

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -472,7 +472,7 @@ bool LLMenuItemGL::handleMouseDown( S32 x, S32 y, MASK mask)
     return LLView::handleMouseDown(x, y, mask);
 }
 
-bool LLMenuItemGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLMenuItemGL::handleScrollWheel( S32 x, S32 y, LLScrollDelta delta )
 {
     // If the menu is scrollable let it handle the wheel event.
     return !getMenu()->isScrollable();
@@ -3214,11 +3214,12 @@ bool LLMenuGL::handleHover( S32 x, S32 y, MASK mask )
     return true;
 }
 
-bool LLMenuGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLMenuGL::handleScrollWheel( S32 x, S32 y, LLScrollDelta delta )
 {
     if (!mScrollable)
         return blockMouseEvent(x, y);
 
+    S32 clicks = delta.mClicks;
     if( clicks > 0 )
     {
         while( clicks-- )

--- a/indra/llui/llmenugl.h
+++ b/indra/llui/llmenugl.h
@@ -166,7 +166,7 @@ public:
     virtual bool handleKeyHere( KEY key, MASK mask );
     virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
     virtual bool handleMouseUp( S32 x, S32 y, MASK mask );
-    virtual bool handleScrollWheel( S32 x, S32 y, S32 clicks );
+    virtual bool handleScrollWheel( S32 x, S32 y, LLScrollDelta delta );
 
     virtual void    onMouseEnter(S32 x, S32 y, MASK mask);
     virtual void    onMouseLeave(S32 x, S32 y, MASK mask);
@@ -443,7 +443,7 @@ public:
     // LLView Functionality
     /*virtual*/ bool handleUnicodeCharHere( llwchar uni_char );
     /*virtual*/ bool handleHover( S32 x, S32 y, MASK mask );
-    /*virtual*/ bool handleScrollWheel( S32 x, S32 y, S32 clicks );
+    /*virtual*/ bool handleScrollWheel( S32 x, S32 y, LLScrollDelta delta );
     /*virtual*/ void draw( void );
     /*virtual*/ void drawBackground(LLMenuItemGL* itemp, F32 alpha);
     /*virtual*/ void setVisible(bool visible);

--- a/indra/llui/llmodaldialog.cpp
+++ b/indra/llui/llmodaldialog.cpp
@@ -243,9 +243,9 @@ bool LLModalDialog::handleMouseUp(S32 x, S32 y, MASK mask)
     return true;
 }
 
-bool LLModalDialog::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLModalDialog::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    childrenHandleScrollWheel(x, y, clicks);
+    childrenHandleScrollWheel(x, y, delta);
     return true;
 }
 

--- a/indra/llui/llmodaldialog.h
+++ b/indra/llui/llmodaldialog.h
@@ -52,7 +52,7 @@ public:
     /*virtual*/ bool    handleMouseDown(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleMouseUp(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleHover(S32 x, S32 y, MASK mask);
-    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ bool    handleDoubleClick(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleRightMouseDown(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleKeyHere(KEY key, MASK mask );

--- a/indra/llui/llscrollbar.cpp
+++ b/indra/llui/llscrollbar.cpp
@@ -404,20 +404,28 @@ bool LLScrollbar::handleHover(S32 x, S32 y, MASK mask)
 } // end handleHover
 
 
+// Accumulate fractional line movement from the precise (sub-notch) scroll
+// delta and apply whole lines as the accumulator crosses an integer, carrying
+// the remainder. mDocPos is integer "lines", so this residue is what lets
+// high-resolution wheels and touchpads scroll smoothly instead of dropping
+// everything below one whole notch. A whole notch (precise == 1) moves
+// mStepSize lines exactly as before.
+bool LLScrollbar::scrollByWheel(F32 precise)
+{
+    mScrollWheelResidue += precise * (F32)mStepSize;
+    S32 lines = lltrunc(mScrollWheelResidue);
+    mScrollWheelResidue -= (F32)lines;
+    return changeLine(lines, true);
+}
+
 bool LLScrollbar::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    bool handled = changeLine( delta.mClicks * mStepSize, true );
-    return handled;
+    return scrollByWheel(delta.mPrecise);
 }
 
 bool LLScrollbar::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    bool handled = false;
-    if (LLScrollbar::HORIZONTAL == mOrientation)
-    {
-        handled = changeLine(delta.mClicks * mStepSize, true);
-    }
-    return handled;
+    return (LLScrollbar::HORIZONTAL == mOrientation) ? scrollByWheel(delta.mPrecise) : false;
 }
 
 bool LLScrollbar::handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop,

--- a/indra/llui/llscrollbar.cpp
+++ b/indra/llui/llscrollbar.cpp
@@ -428,11 +428,21 @@ bool LLScrollbar::scrollByWheel(F32 precise)
     // that.
     if (precise > 0.f)
     {
-        return mDocPos < getDocPosMax();
+        if (mDocPos < getDocPosMax())
+        {
+            return true;
+        }
+        mScrollWheelResidue = 0.f; // forwarding to parent; don't keep partial progress
+        return false;
     }
     if (precise < 0.f)
     {
-        return mDocPos > 0;
+        if (mDocPos > 0)
+        {
+            return true;
+        }
+        mScrollWheelResidue = 0.f; // forwarding to parent; don't keep partial progress
+        return false;
     }
     return false;
 }

--- a/indra/llui/llscrollbar.cpp
+++ b/indra/llui/llscrollbar.cpp
@@ -415,7 +415,26 @@ bool LLScrollbar::scrollByWheel(F32 precise)
     mScrollWheelResidue += precise * (F32)mStepSize;
     S32 lines = lltrunc(mScrollWheelResidue);
     mScrollWheelResidue -= (F32)lines;
-    return changeLine(lines, true);
+    if (changeLine(lines, true))
+    {
+        return true; // moved at least one whole line
+    }
+    // No whole line crossed yet (sub-notch precise scroll). Still report the
+    // gesture as handled so it isn't forwarded to a parent scroller, which would
+    // otherwise advance on the same high-resolution / touchpad gesture (a
+    // visible double-scroll in nested non-opaque scroll areas). The one
+    // exception is being parked at the boundary in the scroll direction: there
+    // the legacy behavior was to let the event chain to the parent, so preserve
+    // that.
+    if (precise > 0.f)
+    {
+        return mDocPos < getDocPosMax();
+    }
+    if (precise < 0.f)
+    {
+        return mDocPos > 0;
+    }
+    return false;
 }
 
 bool LLScrollbar::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)

--- a/indra/llui/llscrollbar.cpp
+++ b/indra/llui/llscrollbar.cpp
@@ -404,18 +404,18 @@ bool LLScrollbar::handleHover(S32 x, S32 y, MASK mask)
 } // end handleHover
 
 
-bool LLScrollbar::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollbar::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    bool handled = changeLine( clicks * mStepSize, true );
+    bool handled = changeLine( delta.mClicks * mStepSize, true );
     return handled;
 }
 
-bool LLScrollbar::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollbar::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     bool handled = false;
     if (LLScrollbar::HORIZONTAL == mOrientation)
     {
-        handled = changeLine(clicks * mStepSize, true);
+        handled = changeLine(delta.mClicks * mStepSize, true);
     }
     return handled;
 }

--- a/indra/llui/llscrollbar.h
+++ b/indra/llui/llscrollbar.h
@@ -130,6 +130,7 @@ public:
 private:
     void                updateThumbRect();
     bool                changeLine(S32 delta, bool update_thumb );
+    bool                scrollByWheel(F32 precise); // precise sub-notch wheel delta -> whole lines + residue
 
     callback_t          mChangeCallback;
 
@@ -138,6 +139,7 @@ private:
     S32                 mDocPos;        // Position within the doc that the scrollbar is modeling, in "lines" (user size)
     S32                 mPageSize;      // Maximum number of lines that can be seen at one time.
     S32                 mStepSize;
+    F32                 mScrollWheelResidue = 0.f; // carries sub-line precise scroll between events
     bool                mDocChanged;
 
     LLRect              mThumbRect;

--- a/indra/llui/llscrollbar.h
+++ b/indra/llui/llscrollbar.h
@@ -87,8 +87,8 @@ public:
     virtual bool    handleMouseUp(S32 x, S32 y, MASK mask);
     virtual bool    handleDoubleClick(S32 x, S32 y, MASK mask);
     virtual bool    handleHover(S32 x, S32 y, MASK mask);
-    virtual bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
-    virtual bool    handleScrollHWheel(S32 x, S32 y, S32 clicks);
+    virtual bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    virtual bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     virtual bool    handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop,
         EDragAndDropType cargo_type, void *cargo_data, EAcceptance *accept, std::string &tooltip_msg);
 

--- a/indra/llui/llscrollcontainer.cpp
+++ b/indra/llui/llscrollcontainer.cpp
@@ -257,11 +257,11 @@ bool LLScrollContainer::handleUnicodeCharHere(llwchar uni_char)
     return false;
 }
 
-bool LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLScrollContainer::handleScrollWheel( S32 x, S32 y, LLScrollDelta delta )
 {
     // Give event to my child views - they may have scroll bars
     // (Bad UI design, but technically possible.)
-    if (LLUICtrl::handleScrollWheel(x,y,clicks))
+    if (LLUICtrl::handleScrollWheel(x,y,delta))
         return true;
 
     // When the vertical scrollbar is visible, scroll wheel
@@ -273,7 +273,7 @@ bool LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
         && vertical->getEnabled())
     {
         // Pretend the mouse is over the scrollbar
-        if (vertical->handleScrollWheel( 0, 0, clicks ) )
+        if (vertical->handleScrollWheel( 0, 0, delta ) )
         {
             updateScroll();
         }
@@ -286,7 +286,7 @@ bool LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
     // LLView::childrenHandleScrollWheel().
     if (horizontal->getVisible()
         && horizontal->getEnabled()
-        && horizontal->handleScrollWheel( 0, 0, clicks ) )
+        && horizontal->handleScrollWheel( 0, 0, delta ) )
     {
         updateScroll();
         return true;
@@ -294,9 +294,9 @@ bool LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
     return false;
 }
 
-bool LLScrollContainer::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollContainer::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    if (LLUICtrl::handleScrollHWheel(x,y,clicks))
+    if (LLUICtrl::handleScrollHWheel(x,y,delta))
     {
         return true;
     }
@@ -304,7 +304,7 @@ bool LLScrollContainer::handleScrollHWheel(S32 x, S32 y, S32 clicks)
     LLScrollbar* horizontal = mScrollbar[HORIZONTAL];
     if (horizontal->getVisible()
         && horizontal->getEnabled()
-        && horizontal->handleScrollHWheel( 0, 0, clicks ) )
+        && horizontal->handleScrollHWheel( 0, 0, delta ) )
     {
         updateScroll();
         return true;

--- a/indra/llui/llscrollcontainer.h
+++ b/indra/llui/llscrollcontainer.h
@@ -109,8 +109,8 @@ public:
     virtual void    reshape(S32 width, S32 height, bool called_from_parent = true);
     virtual bool    handleKeyHere(KEY key, MASK mask);
     virtual bool    handleUnicodeCharHere(llwchar uni_char);
-    virtual bool    handleScrollWheel( S32 x, S32 y, S32 clicks );
-    virtual bool    handleScrollHWheel( S32 x, S32 y, S32 clicks );
+    virtual bool    handleScrollWheel( S32 x, S32 y, LLScrollDelta delta );
+    virtual bool    handleScrollHWheel( S32 x, S32 y, LLScrollDelta delta );
     virtual bool    handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop,
                                    EDragAndDropType cargo_type,
                                    void* cargo_data,

--- a/indra/llui/llscrolllistctrl.cpp
+++ b/indra/llui/llscrolllistctrl.cpp
@@ -1849,11 +1849,11 @@ void LLScrollListCtrl::setEnabled(bool enabled)
     mScrollbar->setTabStop(!enabled && mScrollbar->getPageSize() < mScrollbar->getDocSize());
 }
 
-bool LLScrollListCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollListCtrl::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     bool handled = false;
     // Pretend the mouse is over the scrollbar
-    handled = mScrollbar->handleScrollWheel( 0, 0, clicks );
+    handled = mScrollbar->handleScrollWheel( 0, 0, delta );
 
     if (mMouseWheelOpaque)
     {
@@ -1863,11 +1863,11 @@ bool LLScrollListCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
     return handled;
 }
 
-bool LLScrollListCtrl::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollListCtrl::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     bool handled = false;
     // Pretend the mouse is over the scrollbar
-    handled = mScrollbar->handleScrollHWheel( 0, 0, clicks );
+    handled = mScrollbar->handleScrollHWheel( 0, 0, delta );
 
     if (mMouseWheelOpaque)
     {

--- a/indra/llui/llscrolllistctrl.h
+++ b/indra/llui/llscrolllistctrl.h
@@ -363,8 +363,8 @@ public:
     /*virtual*/ bool    handleHover(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleKeyHere(KEY key, MASK mask);
     /*virtual*/ bool    handleUnicodeCharHere(llwchar uni_char);
-    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
-    /*virtual*/ bool    handleScrollHWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    /*virtual*/ bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ bool    handleToolTip(S32 x, S32 y, MASK mask);
     /*virtual*/ void    setEnabled(bool enabled);
     /*virtual*/ void    setFocus( bool b );

--- a/indra/llui/llslider.cpp
+++ b/indra/llui/llslider.cpp
@@ -277,26 +277,26 @@ bool LLSlider::handleKeyHere(KEY key, MASK mask)
     return handled;
 }
 
-bool LLSlider::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLSlider::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if ( mOrientation == VERTICAL )
     {
-        F32 new_val = getValueF32() - clicks * getIncrement();
+        F32 new_val = getValueF32() - delta.mClicks * getIncrement();
         setValueAndCommit(new_val);
         return true;
     }
-    return LLF32UICtrl::handleScrollWheel(x,y,clicks);
+    return LLF32UICtrl::handleScrollWheel(x,y,delta);
 }
 
-bool LLSlider::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLSlider::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mOrientation == HORIZONTAL)
     {
-        F32 new_val = getValueF32() - clicks * getIncrement();
+        F32 new_val = getValueF32() - delta.mClicks * getIncrement();
         setValueAndCommit(new_val);
         return true;
     }
-    return LLF32UICtrl::handleScrollHWheel(x, y, clicks);
+    return LLF32UICtrl::handleScrollHWheel(x, y, delta);
 }
 
 void LLSlider::draw()

--- a/indra/llui/llslider.h
+++ b/indra/llui/llslider.h
@@ -76,8 +76,8 @@ public:
     virtual bool    handleMouseUp(S32 x, S32 y, MASK mask);
     virtual bool    handleMouseDown(S32 x, S32 y, MASK mask);
     virtual bool    handleKeyHere(KEY key, MASK mask);
-    virtual bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
-    virtual bool    handleScrollHWheel(S32 x, S32 y, S32 clicks);
+    virtual bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    virtual bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     virtual void    draw();
 
 private:

--- a/indra/llui/llspinctrl.cpp
+++ b/indra/llui/llspinctrl.cpp
@@ -478,8 +478,9 @@ void LLSpinCtrl::reportInvalidData()
     make_ui_sound("UISndBadKeystroke");
 }
 
-bool LLSpinCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLSpinCtrl::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
+    S32 clicks = delta.mClicks;
     if( clicks > 0 )
     {
         while( clicks-- )

--- a/indra/llui/llspinctrl.h
+++ b/indra/llui/llspinctrl.h
@@ -88,7 +88,7 @@ public:
 
     void            forceEditorCommit();            // for commit on external button
 
-    virtual bool    handleScrollWheel(S32 x,S32 y,S32 clicks);
+    virtual bool    handleScrollWheel(S32 x,S32 y,LLScrollDelta delta);
     virtual bool    handleKeyHere(KEY key, MASK mask);
 
     void            onEditorCommit(const LLSD& data);

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1469,15 +1469,15 @@ bool LLTextBase::handleHover(S32 x, S32 y, MASK mask)
 }
 
 //virtual
-bool LLTextBase::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLTextBase::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
-    if (cur_segment && cur_segment->handleScrollWheel(x, y, clicks))
+    if (cur_segment && cur_segment->handleScrollWheel(x, y, delta))
     {
         return true;
     }
 
-    return LLUICtrl::handleScrollWheel(x, y, clicks);
+    return LLUICtrl::handleScrollWheel(x, y, delta);
 }
 
 //virtual
@@ -3842,8 +3842,8 @@ bool LLTextSegment::handleRightMouseDown(S32 x, S32 y, MASK mask) { return false
 bool LLTextSegment::handleRightMouseUp(S32 x, S32 y, MASK mask) { return false; }
 bool LLTextSegment::handleDoubleClick(S32 x, S32 y, MASK mask) { return false; }
 bool LLTextSegment::handleHover(S32 x, S32 y, MASK mask) { return false; }
-bool LLTextSegment::handleScrollWheel(S32 x, S32 y, S32 clicks) { return false; }
-bool LLTextSegment::handleScrollHWheel(S32 x, S32 y, S32 clicks) { return false; }
+bool LLTextSegment::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) { return false; }
+bool LLTextSegment::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta) { return false; }
 bool LLTextSegment::handleToolTip(S32 x, S32 y, MASK mask) { return false; }
 const std::string&  LLTextSegment::getName() const
 {

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -111,8 +111,8 @@ public:
     /*virtual*/ bool            handleRightMouseUp(S32 x, S32 y, MASK mask);
     /*virtual*/ bool            handleDoubleClick(S32 x, S32 y, MASK mask);
     /*virtual*/ bool            handleHover(S32 x, S32 y, MASK mask);
-    /*virtual*/ bool            handleScrollWheel(S32 x, S32 y, S32 clicks);
-    /*virtual*/ bool            handleScrollHWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool            handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    /*virtual*/ bool            handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ bool            handleToolTip(S32 x, S32 y, MASK mask);
     /*virtual*/ const std::string&  getName() const;
     /*virtual*/ void            onMouseCaptureLost();
@@ -391,7 +391,7 @@ public:
     /*virtual*/ bool        handleRightMouseUp(S32 x, S32 y, MASK mask) override;
     /*virtual*/ bool        handleDoubleClick(S32 x, S32 y, MASK mask) override;
     /*virtual*/ bool        handleHover(S32 x, S32 y, MASK mask) override;
-    /*virtual*/ bool        handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    /*virtual*/ bool        handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
     /*virtual*/ bool        handleToolTip(S32 x, S32 y, MASK mask) override;
 
     // LLView interface

--- a/indra/llui/lltooltip.cpp
+++ b/indra/llui/lltooltip.cpp
@@ -117,7 +117,7 @@ bool LLToolTipView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 }
 
 
-bool LLToolTipView::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLToolTipView::handleScrollWheel( S32 x, S32 y, LLScrollDelta delta )
 {
     LLToolTipMgr::instance().blockToolTips();
     return false;

--- a/indra/llui/lltooltip.h
+++ b/indra/llui/lltooltip.h
@@ -48,7 +48,7 @@ public:
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleMiddleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleRightMouseDown(S32 x, S32 y, MASK mask) override;
-    bool handleScrollWheel( S32 x, S32 y, S32 clicks ) override;
+    bool handleScrollWheel( S32 x, S32 y, LLScrollDelta delta ) override;
 
     void drawStickyRect();
 

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -1146,14 +1146,14 @@ bool LLView::handleDoubleClick(S32 x, S32 y, MASK mask)
     return childrenHandleDoubleClick( x, y, mask ) != NULL;
 }
 
-bool LLView::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLView::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return childrenHandleScrollWheel( x, y, clicks ) != NULL;
+    return childrenHandleScrollWheel( x, y, delta ) != NULL;
 }
 
-bool LLView::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLView::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return childrenHandleScrollHWheel( x, y, clicks ) != NULL;
+    return childrenHandleScrollHWheel( x, y, delta ) != NULL;
 }
 
 bool LLView::handleRightMouseDown(S32 x, S32 y, MASK mask)
@@ -1176,14 +1176,14 @@ bool LLView::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
     return childrenHandleMiddleMouseUp( x, y, mask ) != NULL;
 }
 
-LLView* LLView::childrenHandleScrollWheel(S32 x, S32 y, S32 clicks)
+LLView* LLView::childrenHandleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return childrenHandleMouseEvent(&LLView::handleScrollWheel, x, y, clicks, false);
+    return childrenHandleMouseEvent(&LLView::handleScrollWheel, x, y, delta, false);
 }
 
-LLView* LLView::childrenHandleScrollHWheel(S32 x, S32 y, S32 clicks)
+LLView* LLView::childrenHandleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return childrenHandleMouseEvent(&LLView::handleScrollHWheel, x, y, clicks, false);
+    return childrenHandleMouseEvent(&LLView::handleScrollHWheel, x, y, delta, false);
 }
 
 // Called during downward traversal

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -429,8 +429,8 @@ public:
     /*virtual*/ bool    handleMiddleMouseUp(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleMiddleMouseDown(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleDoubleClick(S32 x, S32 y, MASK mask);
-    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
-    /*virtual*/ bool    handleScrollHWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    /*virtual*/ bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ bool    handleRightMouseDown(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleRightMouseUp(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleToolTip(S32 x, S32 y, MASK mask);
@@ -560,8 +560,8 @@ protected:
     LLView* childrenHandleMiddleMouseUp(S32 x, S32 y, MASK mask);
     LLView* childrenHandleMiddleMouseDown(S32 x, S32 y, MASK mask);
     LLView* childrenHandleDoubleClick(S32 x, S32 y, MASK mask);
-    LLView* childrenHandleScrollWheel(S32 x, S32 y, S32 clicks);
-    LLView* childrenHandleScrollHWheel(S32 x, S32 y, S32 clicks);
+    LLView* childrenHandleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    LLView* childrenHandleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     LLView* childrenHandleRightMouseDown(S32 x, S32 y, MASK mask);
     LLView* childrenHandleRightMouseUp(S32 x, S32 y, MASK mask);
     LLView* childrenHandleToolTip(S32 x, S32 y, MASK mask);

--- a/indra/llwindow/CMakeLists.txt
+++ b/indra/llwindow/CMakeLists.txt
@@ -73,15 +73,32 @@ if(USE_SDL_WINDOW)
 endif()
 
 if(WINDOWS)
+  # lldxhardware (GPU/driver/VRAM queries) is used regardless of window
+  # backend — the SDL backend calls LLDXHardware::updateVRAMBudgetFromDXGI()
+  # and llappviewer queries WMI driver versions.
   target_sources(llwindow
     PRIVATE
-      llwindowwin32.cpp
       lldxhardware.cpp
-      llkeyboardwin32.cpp
-      lldragdropwin32.cpp
+    PUBLIC
+      lldxhardware.h
+  )
+
+  # The native Win32 backend is only built when SDL isn't driving the window.
+  # llkeyboardwin32 in particular can't compile under LL_SDL_WINDOW (the
+  # NATIVE_KEY_TYPE typedef switches to the SDL flavor), and the factory never
+  # instantiates LLWindowWin32 on an SDL build anyway. Headers stay listed so
+  # llviewerwindow.cpp's (guarded) include still resolves.
+  if(NOT USE_SDL_WINDOW)
+    target_sources(llwindow
+      PRIVATE
+        llwindowwin32.cpp
+        llkeyboardwin32.cpp
+        lldragdropwin32.cpp
+    )
+  endif()
+  target_sources(llwindow
     PUBLIC
       llwindowwin32.h
-      lldxhardware.h
       llkeyboardwin32.h
       lldragdropwin32.h
   )

--- a/indra/llwindow/CMakeLists.txt
+++ b/indra/llwindow/CMakeLists.txt
@@ -25,6 +25,7 @@ set(llwindow_BASE_HEADER_FILES
   llkeyboard.h
   llkeyboardheadless.h
   llmousehandler.h
+  llscrolldelta.h
   llwindow.h
   llwindowheadless.h
   llwindowcallbacks.h

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -36,6 +36,7 @@
 
 #include <wbemidl.h>
 #include <comdef.h>
+#include <dxgi1_4.h>
 
 #include <boost/tokenizer.hpp>
 
@@ -43,8 +44,10 @@
 
 #include "llerror.h"
 
+#include "llgl.h"
 #include "llstring.h"
 #include "llstl.h"
+#include "llsys.h"
 #include "lltimer.h"
 
 LLDXHardware gDXHardware;
@@ -462,6 +465,118 @@ LCleanup:
 
     CoUninitialize();
     return ret;
+}
+
+// static
+void LLDXHardware::updateVRAMBudgetFromDXGI()
+{
+    if ((gGLManager.mHasAMDAssociations || gGLManager.mHasNVXGpuMemoryInfo) && gGLManager.mVRAM != 0)
+    { // OpenGL already told us the memory budget, don't ask DX
+        return;
+    }
+
+    // Use DXGI to check memory (because WMI doesn't report more than 4Gb)
+    IDXGIFactory4* p_factory = nullptr;
+
+    HRESULT res = CreateDXGIFactory1(__uuidof(IDXGIFactory4), (void**)&p_factory);
+
+    if (FAILED(res))
+    {
+        LL_WARNS() << "CreateDXGIFactory1 failed: 0x" << std::hex << res << LL_ENDL;
+    }
+    else
+    {
+        IDXGIAdapter3* p_dxgi_adapter = nullptr;
+        UINT graphics_adapter_index = 0;
+        while (true)
+        {
+            res = p_factory->EnumAdapters(graphics_adapter_index, reinterpret_cast<IDXGIAdapter**>(&p_dxgi_adapter));
+            if (FAILED(res))
+            {
+                if (graphics_adapter_index == 0)
+                {
+                    LL_WARNS() << "EnumAdapters failed: 0x" << std::hex << res << LL_ENDL;
+                }
+            }
+            else
+            {
+                if (graphics_adapter_index == 0) // Should it check largest one isntead of first?
+                {
+                    DXGI_QUERY_VIDEO_MEMORY_INFO info;
+                    p_dxgi_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &info);
+
+                    // Alternatively use GetDesc from below to get adapter's memory
+                    UINT64 budget_mb = info.Budget / (1024 * 1024);
+                    if (gGLManager.mIsIntel)
+                    {
+                        U32Megabytes phys_mb = gSysMemory.getPhysicalMemoryKB();
+                        LL_WARNS() << "Physical memory: " << phys_mb << " MB" << LL_ENDL;
+
+                        if (phys_mb > 0)
+                        {
+                            if (gGLManager.mIsIntel)
+                            {
+                                // Intel uses 'shared' vram, cap it to 25% of total memory
+                                // Todo: consider a way of detecting integrated Intel and AMD
+                                budget_mb = llmin(budget_mb, (UINT64)(phys_mb * 0.25));
+                            }
+                            else
+                            {
+                                // More budget is generally better, but the way viewer
+                                // utilizes even dedicated VRAM leaves a footprint in RAM
+                                budget_mb = llmin(budget_mb, (UINT64)(phys_mb * 0.75));
+                            }
+                        }
+                        else
+                        {
+                            // if no data available, cap to 2Gb
+                            budget_mb = llmin(budget_mb, (UINT64)2048);
+                        }
+                    }
+                    if (gGLManager.mVRAM < (S32)budget_mb)
+                    {
+                        gGLManager.mVRAM = (S32)budget_mb;
+                        LL_INFOS("RenderInit") << "New VRAM Budget (DX9): " << gGLManager.mVRAM << " MB" << LL_ENDL;
+                    }
+                    else
+                    {
+                        LL_INFOS("RenderInit") << "VRAM Budget (DX9): " << budget_mb
+                            << " MB, current (WMI): " << gGLManager.mVRAM << " MB" << LL_ENDL;
+                    }
+                }
+
+                DXGI_ADAPTER_DESC desc;
+                p_dxgi_adapter->GetDesc(&desc);
+                std::wstring description_w((wchar_t*)desc.Description);
+                std::string description = ll_convert_wide_to_string(description_w);
+                LL_INFOS("Window") << "Graphics adapter index: " << graphics_adapter_index << ", "
+                    << "Description: " << description << ", "
+                    << "DeviceId: " << desc.DeviceId << ", "
+                    << "SubSysId: " << desc.SubSysId << ", "
+                    << "AdapterLuid: " << desc.AdapterLuid.HighPart << "_" << desc.AdapterLuid.LowPart << ", "
+                    << "DedicatedVideoMemory: " << desc.DedicatedVideoMemory / 1024 / 1024 << ", "
+                    << "DedicatedSystemMemory: " << desc.DedicatedSystemMemory / 1024 / 1024 << ", "
+                    << "SharedSystemMemory: " << desc.SharedSystemMemory / 1024 / 1024 << LL_ENDL;
+            }
+
+            if (p_dxgi_adapter)
+            {
+                p_dxgi_adapter->Release();
+                p_dxgi_adapter = NULL;
+            }
+            else
+            {
+                break;
+            }
+
+            graphics_adapter_index++;
+        }
+    }
+
+    if (p_factory)
+    {
+        p_factory->Release();
+    }
 }
 
 #endif

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -486,11 +486,11 @@ void LLDXHardware::updateVRAMBudgetFromDXGI()
     }
     else
     {
-        IDXGIAdapter3* p_dxgi_adapter = nullptr;
+        IDXGIAdapter* p_dxgi_adapter = nullptr;
         UINT graphics_adapter_index = 0;
         while (true)
         {
-            res = p_factory->EnumAdapters(graphics_adapter_index, reinterpret_cast<IDXGIAdapter**>(&p_dxgi_adapter));
+            res = p_factory->EnumAdapters(graphics_adapter_index, &p_dxgi_adapter);
             if (FAILED(res))
             {
                 if (graphics_adapter_index == 0)
@@ -502,8 +502,25 @@ void LLDXHardware::updateVRAMBudgetFromDXGI()
             {
                 if (graphics_adapter_index == 0) // Should it check largest one isntead of first?
                 {
-                    DXGI_QUERY_VIDEO_MEMORY_INFO info;
-                    p_dxgi_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &info);
+                    // EnumAdapters hands back an IDXGIAdapter; QueryInterface up
+                    // to IDXGIAdapter3 for QueryVideoMemoryInfo (Win10+). Zero-init
+                    // info and check the HRESULT so a failed query can't feed
+                    // garbage Budget into the VRAM estimate (it just leaves it 0).
+                    IDXGIAdapter3* p_dxgi_adapter3 = nullptr;
+                    DXGI_QUERY_VIDEO_MEMORY_INFO info = {};
+                    if (SUCCEEDED(p_dxgi_adapter->QueryInterface(__uuidof(IDXGIAdapter3), (void**)&p_dxgi_adapter3)) && p_dxgi_adapter3)
+                    {
+                        if (FAILED(p_dxgi_adapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &info)))
+                        {
+                            info = {};
+                            LL_WARNS() << "QueryVideoMemoryInfo failed" << LL_ENDL;
+                        }
+                        p_dxgi_adapter3->Release();
+                    }
+                    else
+                    {
+                        LL_WARNS() << "IDXGIAdapter3 unavailable; skipping DXGI VRAM budget" << LL_ENDL;
+                    }
 
                     // Alternatively use GetDesc from below to get adapter's memory
                     UINT64 budget_mb = info.Budget / (1024 * 1024);

--- a/indra/llwindow/lldxhardware.h
+++ b/indra/llwindow/lldxhardware.h
@@ -51,6 +51,12 @@ public:
     std::string getDriverVersionWMI(EGPUVendor vendor);
 
     LLSD getDisplayInfo();
+
+    // Raise gGLManager.mVRAM to the DXGI video-memory budget when the GL
+    // vendor paths (AMD associations / NVX memory info) didn't report one —
+    // matters mainly for Intel iGPUs. Must run with GL initialized. Shared
+    // by LLWindowWin32's window thread (checkDXMem) and the SDL backend.
+    static void updateVRAMBudgetFromDXGI();
 };
 
 extern LLDXHardware gDXHardware;

--- a/indra/llwindow/llkeyboard.cpp
+++ b/indra/llwindow/llkeyboard.cpp
@@ -47,7 +47,7 @@ LLKeyStringTranslatorFunc*  LLKeyboard::mStringTranslator = NULL;   // Used for 
 // Class Implementation
 //
 
-LLKeyboard::LLKeyboard() : mCallbacks(NULL)
+LLKeyboard::LLKeyboard() : mCallbacks(NULL), mNumpadDistinct(ND_NUMLOCK_OFF)
 {
     S32 i;
 

--- a/indra/llwindow/llkeyboard.h
+++ b/indra/llwindow/llkeyboard.h
@@ -61,6 +61,18 @@ public:
     // on non-linux platforms we can get by with a smaller native key type
     typedef U16 NATIVE_KEY_TYPE;
 #endif
+
+    // Controls whether the numpad emits distinct KEY_PAD_* codes (so it can
+    // drive avatar/camera independently of the arrow keys and digit row) or
+    // is aliased onto them. Driven by the "NumpadControl" setting; the integer
+    // values line up so the S32 setting casts straight to this enum.
+    typedef enum e_numpad_distinct
+    {
+        ND_NEVER,       // numpad behaves like the normal arrow/digit keys
+        ND_NUMLOCK_OFF, // numpad is distinct when NumLock is off
+        ND_NUMLOCK_ON   // numpad is always distinct (for keyboards with no NumLock)
+    } ENumpadDistinct;
+
     LLKeyboard();
     virtual ~LLKeyboard();
 
@@ -101,6 +113,9 @@ public:
     static std::string stringFromAccelerator( MASK accel_mask, KEY key );
     static std::string stringFromAccelerator(MASK accel_mask, EMouseClickType click);
 
+    e_numpad_distinct getNumpadDistinct() { return mNumpadDistinct; }
+    void setNumpadDistinct(e_numpad_distinct val) { mNumpadDistinct = val; }
+
     void setCallbacks(LLWindowCallbacks *cbs) { mCallbacks = cbs; }
     F32             getKeyElapsedTime( KEY key );  // Returns time in seconds since key was pressed.
     S32             getKeyElapsedFrameCount( KEY key );  // Returns time in frames since key was pressed.
@@ -125,6 +140,8 @@ protected:
     KEY             mCurScanKey;        // Used during the scanKeyboard()
 
     static LLKeyStringTranslatorFunc*   mStringTranslator;  // Used for l10n + PC/Mac/Linux accelerator labeling
+
+    e_numpad_distinct mNumpadDistinct;
 
     EKeyboardInsertMode mInsertMode;
 

--- a/indra/llwindow/llkeyboardsdl.cpp
+++ b/indra/llwindow/llkeyboardsdl.cpp
@@ -262,12 +262,22 @@ bool LLKeyboardSDL::handleKeyDown(const LLKeyboard::NATIVE_KEY_TYPE key, const M
     // arrow/nav cluster (adjustNativekeyFromUnhandledMask) before translating.
     if (translateNumpadKey(key, mask, &translated_key))
     {
+        // translateNumpadKey only succeeds for numpad keys; remember the
+        // distinct KEY_PAD_* so the up edge can release it (see handleKeyUp).
+        mNumpadKeyDown[key] = translated_key;
         return handleTranslatedKeyDown(translated_key, translated_mask);
     }
 
     LLKeyboard::NATIVE_KEY_TYPE adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
     if (translateKey(adjusted_nativekey, &translated_key))
     {
+        // A numpad key folded onto the digit/nav cluster (NumLock on, or a
+        // non-distinct mode): record it too so the up edge releases this exact
+        // KEY rather than re-deriving from a possibly-changed NumLock state.
+        if (mTranslateNumpadMap.find(key) != mTranslateNumpadMap.end())
+        {
+            mNumpadKeyDown[key] = translated_key;
+        }
         return handleTranslatedKeyDown(translated_key, translated_mask);
     }
 
@@ -280,8 +290,19 @@ bool LLKeyboardSDL::handleKeyUp(const LLKeyboard::NATIVE_KEY_TYPE key, const MAS
     KEY translated_key = 0;
     MASK translated_mask = updateModifiers(mask);
 
-    // Mirror handleKeyDown exactly: a key pressed as KEY_PAD_* must release as
-    // KEY_PAD_*, or its level stays stuck.
+    // Release exactly what the matching key-down emitted. translateNumpadKey's
+    // distinct-vs-folded decision depends on the live NumLock bit, so
+    // re-translating here would pick a different KEY (and leave the down KEY's
+    // level stuck) if NumLock was toggled while the key was held. Replaying the
+    // recorded down translation keeps press/release symmetric.
+    auto it = mNumpadKeyDown.find(key);
+    if (it != mNumpadKeyDown.end())
+    {
+        translated_key = it->second;
+        mNumpadKeyDown.erase(it);
+        return handleTranslatedKeyUp(translated_key, translated_mask);
+    }
+
     if (translateNumpadKey(key, mask, &translated_key))
     {
         return handleTranslatedKeyUp(translated_key, translated_mask);

--- a/indra/llwindow/llkeyboardsdl.cpp
+++ b/indra/llwindow/llkeyboardsdl.cpp
@@ -104,7 +104,11 @@ LLKeyboardSDL::LLKeyboardSDL()
     mTranslateKeyMap[SDLK_KP_PLUS] = KEY_ADD;
     mTranslateKeyMap[SDLK_KP_MINUS] = KEY_SUBTRACT;
     mTranslateKeyMap[SDLK_KP_MULTIPLY] = KEY_MULTIPLY;
-    mTranslateKeyMap[SDLK_KP_DIVIDE] = KEY_PAD_DIVIDE;
+    // Numpad '/' -> KEY_DIVIDE (not KEY_PAD_DIVIDE) so it matches Win32
+    // (VK_DIVIDE -> KEY_DIVIDE) and keeps driving the "DIVIDE" binding
+    // (start_gesture). The numpad operators stay non-distinct; only the
+    // arrow/nav cluster below participates in numpad-distinct mode.
+    mTranslateKeyMap[SDLK_KP_DIVIDE] = KEY_DIVIDE;
     mTranslateKeyMap[SDLK_F1] = KEY_F1;
     mTranslateKeyMap[SDLK_F2] = KEY_F2;
     mTranslateKeyMap[SDLK_F3] = KEY_F3;
@@ -157,7 +161,10 @@ LLKeyboardSDL::LLKeyboardSDL()
     mTranslateNumpadMap[SDLK_KP_7] = KEY_PAD_HOME;
     mTranslateNumpadMap[SDLK_KP_8] = KEY_PAD_UP;
     mTranslateNumpadMap[SDLK_KP_9] = KEY_PAD_PGUP;
+    // Numpad '.' can arrive as either keysym depending on layout/platform;
+    // adjustNativekeyFromUnhandledMask folds both, so map both here too.
     mTranslateNumpadMap[SDLK_KP_PERIOD] = KEY_PAD_DEL;
+    mTranslateNumpadMap[SDLK_KP_DECIMAL] = KEY_PAD_DEL;
 
     // build inverse numpad map
     for (auto iter = mTranslateNumpadMap.begin();
@@ -246,41 +253,47 @@ LLKeyboard::NATIVE_KEY_TYPE adjustNativekeyFromUnhandledMask(const LLKeyboard::N
 
 bool LLKeyboardSDL::handleKeyDown(const LLKeyboard::NATIVE_KEY_TYPE key, const MASK mask)
 {
-    LLKeyboard::NATIVE_KEY_TYPE adjusted_nativekey;
     KEY translated_key = 0;
-    MASK translated_mask = MASK_NONE;
-    bool handled = false;
+    MASK translated_mask = updateModifiers(mask);
 
-    adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
-
-    translated_mask = updateModifiers(mask);
-
-    if(translateNumpadKey(adjusted_nativekey, &translated_key))
+    // Numpad-distinct first: when the NumpadControl mode + NumLock state call
+    // for it, emit a KEY_PAD_* code from the raw SDLK_KP_* keysym. Otherwise
+    // fall through to the normal path, which folds NumLock-off numpad onto the
+    // arrow/nav cluster (adjustNativekeyFromUnhandledMask) before translating.
+    if (translateNumpadKey(key, mask, &translated_key))
     {
-        handled = handleTranslatedKeyDown(translated_key, translated_mask);
+        return handleTranslatedKeyDown(translated_key, translated_mask);
     }
 
-    return handled;
+    LLKeyboard::NATIVE_KEY_TYPE adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
+    if (translateKey(adjusted_nativekey, &translated_key))
+    {
+        return handleTranslatedKeyDown(translated_key, translated_mask);
+    }
+
+    return false;
 }
 
 
 bool LLKeyboardSDL::handleKeyUp(const LLKeyboard::NATIVE_KEY_TYPE key, const MASK mask)
 {
-    LLKeyboard::NATIVE_KEY_TYPE adjusted_nativekey;
     KEY translated_key = 0;
-    U32 translated_mask = MASK_NONE;
-    bool handled = false;
+    MASK translated_mask = updateModifiers(mask);
 
-    adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
-
-    translated_mask = updateModifiers(mask);
-
-    if(translateNumpadKey(adjusted_nativekey, &translated_key))
+    // Mirror handleKeyDown exactly: a key pressed as KEY_PAD_* must release as
+    // KEY_PAD_*, or its level stays stuck.
+    if (translateNumpadKey(key, mask, &translated_key))
     {
-        handled = handleTranslatedKeyUp(translated_key, translated_mask);
+        return handleTranslatedKeyUp(translated_key, translated_mask);
     }
 
-    return handled;
+    LLKeyboard::NATIVE_KEY_TYPE adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
+    if (translateKey(adjusted_nativekey, &translated_key))
+    {
+        return handleTranslatedKeyUp(translated_key, translated_mask);
+    }
+
+    return false;
 }
 
 MASK LLKeyboardSDL::currentMask(bool for_mouse_event)
@@ -335,13 +348,44 @@ void LLKeyboardSDL::scanKeyboard()
 }
 
 
-bool LLKeyboardSDL::translateNumpadKey( const LLKeyboard::NATIVE_KEY_TYPE os_key, KEY *translated_key)
+bool LLKeyboardSDL::translateNumpadKey( const LLKeyboard::NATIVE_KEY_TYPE os_key, const MASK mask, KEY *translated_key)
 {
-    return translateKey(os_key, translated_key);
+    // ND_NEVER: numpad is never distinct, behave like the arrow/digit keys.
+    if (mNumpadDistinct == ND_NEVER)
+    {
+        return false;
+    }
+    // ND_NUMLOCK_OFF: distinct only while NumLock is off; with it on the numpad
+    // types digits. ND_NUMLOCK_ON: always distinct. mask is the raw SDL_Keymod
+    // from the event (event.key.mod), so SDL_KMOD_NUM is the live NumLock bit.
+    if (mNumpadDistinct == ND_NUMLOCK_OFF && (mask & SDL_KMOD_NUM))
+    {
+        return false;
+    }
+
+    // SDL delivers the raw SDLK_KP_* keysym regardless of NumLock (no
+    // hide_numpad in SDL_HINT_KEYCODE_OPTIONS — see llsdl.cpp), so a numpad key
+    // is identifiable directly. Only the arrow/nav cluster is in this map;
+    // operators (+ - * /) deliberately are not, so they keep their KEY_ADD/
+    // KEY_SUBTRACT/KEY_MULTIPLY/KEY_DIVIDE meaning.
+    auto iter = mTranslateNumpadMap.find(os_key);
+    if (iter != mTranslateNumpadMap.end())
+    {
+        *translated_key = iter->second;
+        return true;
+    }
+    return false;
 }
 
 LLKeyboard::NATIVE_KEY_TYPE LLKeyboardSDL::inverseTranslateNumpadKey(const KEY translated_key)
 {
+    // KEY_PAD_* (other than KEY_PAD_CENTER) only exist in the numpad map, so the
+    // base inverse map can't resolve them — consult the numpad inverse first.
+    auto iter = mInvTranslateNumpadMap.find(translated_key);
+    if (iter != mInvTranslateNumpadMap.end())
+    {
+        return iter->second;
+    }
     return inverseTranslateKey(translated_key);
 }
 

--- a/indra/llwindow/llkeyboardsdl.h
+++ b/indra/llwindow/llkeyboardsdl.h
@@ -50,6 +50,11 @@ protected:
 private:
     std::map<LLKeyboard::NATIVE_KEY_TYPE, KEY> mTranslateNumpadMap;  // special map for translating OS keys to numpad keys
     std::map<KEY, LLKeyboard::NATIVE_KEY_TYPE> mInvTranslateNumpadMap; // inverse of the above
+    // The KEY a held numpad key resolved to on its key-down, so key-up releases
+    // the same KEY even if NumLock was toggled mid-press (otherwise the down
+    // KEY's level sticks). SDL delivers a stable SDLK_KP_* keysym per physical
+    // key regardless of NumLock, so the keysym is a reliable handle.
+    std::map<LLKeyboard::NATIVE_KEY_TYPE, KEY> mNumpadKeyDown;
 
 public:
     static U32 mapSDLtoWin( U32 );

--- a/indra/llwindow/llkeyboardsdl.h
+++ b/indra/llwindow/llkeyboardsdl.h
@@ -45,7 +45,7 @@ public:
 protected:
     MASK    updateModifiers(const MASK mask);
     void    setModifierKeyLevel( KEY key, bool new_state );
-    bool    translateNumpadKey( const LLKeyboard::NATIVE_KEY_TYPE os_key, KEY *translated_key );
+    bool    translateNumpadKey( const LLKeyboard::NATIVE_KEY_TYPE os_key, const MASK mask, KEY *translated_key );
     LLKeyboard::NATIVE_KEY_TYPE inverseTranslateNumpadKey(const KEY translated_key);
 private:
     std::map<LLKeyboard::NATIVE_KEY_TYPE, KEY> mTranslateNumpadMap;  // special map for translating OS keys to numpad keys

--- a/indra/llwindow/llkeyboardwin32.cpp
+++ b/indra/llwindow/llkeyboardwin32.cpp
@@ -198,6 +198,25 @@ MASK LLKeyboardWin32::updateModifiers()
 
 
 // mask is ignored, except for extended flag -- we poll the modifier keys for the other flags
+namespace
+{
+    // A NumLock-independent handle for the physical key behind a Win32 VK.
+    // NumLock changes which VK a numpad key sends (VK_NUMPAD2 vs VK_DOWN for one
+    // physical key), but MapVirtualKey resolves both to the same scancode, so the
+    // scancode — plus the extended-key flag, which separates the real arrow/nav
+    // cluster from the numpad — is stable across a NumLock toggle. Returns 0 when
+    // there is no scancode (the caller then skips the down/up replay map).
+    U32 win32PhysicalKeyId(U16 os_key, MASK mask)
+    {
+        U32 sc = ::MapVirtualKey(os_key, MAPVK_VK_TO_VSC);
+        if (!sc)
+        {
+            return 0;
+        }
+        return (mask & MASK_EXTENDED) ? (sc | 0x10000u) : sc;
+    }
+}
+
 bool LLKeyboardWin32::handleKeyDown(const LLKeyboard::NATIVE_KEY_TYPE key, MASK mask)
 {
     KEY     translated_key;
@@ -208,6 +227,16 @@ bool LLKeyboardWin32::handleKeyDown(const LLKeyboard::NATIVE_KEY_TYPE key, MASK 
 
     if (translateExtendedKey(key, mask, &translated_key))
     {
+        // Remember what this physical key resolved to so the matching key-up
+        // releases the SAME KEY. translateExtendedKey's numpad-distinct decision
+        // reads the live NumLock state; without this, toggling NumLock while a
+        // numpad key is held makes the up edge translate to a different KEY and
+        // leaves the down KEY's level stuck (e.g. the avatar keeps walking).
+        U32 phys = win32PhysicalKeyId(key, mask);
+        if (phys)
+        {
+            mKeyDownTranslation[phys] = translated_key;
+        }
         handled = handleTranslatedKeyDown(translated_key, translated_mask);
     }
 
@@ -223,7 +252,18 @@ bool LLKeyboardWin32::handleKeyUp(const LLKeyboard::NATIVE_KEY_TYPE key, MASK ma
 
     translated_mask = updateModifiers();
 
-    if (translateExtendedKey(key, mask, &translated_key))
+    // Prefer the translation recorded on key-down so press/release stay
+    // symmetric across a mid-press NumLock toggle; fall back to translating the
+    // up edge for keys with no recorded down (e.g. held across a focus change).
+    U32 phys = win32PhysicalKeyId(key, mask);
+    std::map<U32, KEY>::iterator it = (phys != 0) ? mKeyDownTranslation.find(phys) : mKeyDownTranslation.end();
+    if (it != mKeyDownTranslation.end())
+    {
+        translated_key = it->second;
+        mKeyDownTranslation.erase(it);
+        handled = handleTranslatedKeyUp(translated_key, translated_mask);
+    }
+    else if (translateExtendedKey(key, mask, &translated_key))
     {
         handled = handleTranslatedKeyUp(translated_key, translated_mask);
     }

--- a/indra/llwindow/llkeyboardwin32.cpp
+++ b/indra/llwindow/llkeyboardwin32.cpp
@@ -131,11 +131,12 @@ LLKeyboardWin32::LLKeyboardWin32()
     mTranslateNumpadMap[0x67] = KEY_PAD_HOME;   // keypad 7
     mTranslateNumpadMap[0x68] = KEY_PAD_UP;     // keypad 8
     mTranslateNumpadMap[0x69] = KEY_PAD_PGUP;   // keypad 9
-    mTranslateNumpadMap[0x6A] = KEY_PAD_MULTIPLY;   // keypad *
-    mTranslateNumpadMap[0x6B] = KEY_PAD_ADD;    // keypad +
-    mTranslateNumpadMap[0x6D] = KEY_PAD_SUBTRACT;   // keypad -
+    // Numpad '.' is the only non-digit member of the distinct (arrow/nav)
+    // cluster. The operators + - * / are intentionally NOT mapped here: they
+    // keep their KEY_ADD/SUBTRACT/MULTIPLY/KEY_DIVIDE codes in every mode (to
+    // match LLKeyboardSDL), so numpad +/- can drive zoom via those bindings and
+    // numpad '/' keeps firing the start_gesture binding.
     mTranslateNumpadMap[0x6E] = KEY_PAD_DEL;    // keypad .
-    mTranslateNumpadMap[0x6F] = KEY_PAD_DIVIDE; // keypad /
 
     for (iter = mTranslateNumpadMap.begin(); iter != mTranslateNumpadMap.end(); iter++)
     {
@@ -274,13 +275,59 @@ void LLKeyboardWin32::scanKeyboard()
 
 bool LLKeyboardWin32::translateExtendedKey(const U16 os_key, const MASK mask, KEY *translated_key)
 {
-    return translateKey(os_key, translated_key);
+    // Whether the numpad should emit distinct KEY_PAD_* codes right now. Mirrors
+    // LLKeyboardSDL::translateNumpadKey so both backends behave identically.
+    const bool numlock_on = (GetKeyState(VK_NUMLOCK) & 1) != 0;
+    const bool distinct = (mNumpadDistinct == ND_NUMLOCK_ON) ||
+                          (mNumpadDistinct == ND_NUMLOCK_OFF && !numlock_on);
+
+    // With NumLock on, the numpad digits arrive as VK_NUMPAD0..9 (and '.' as
+    // VK_DECIMAL); map them straight to KEY_PAD_* when distinct.
+    if (distinct)
+    {
+        std::map<U16, KEY>::iterator iter = mTranslateNumpadMap.find(os_key);
+        if (iter != mTranslateNumpadMap.end())
+        {
+            *translated_key = iter->second;
+            return true;
+        }
+    }
+
+    bool success = translateKey(os_key, translated_key);
+    if (!success || !distinct)
+    {
+        return success;
+    }
+
+    // With NumLock off, the numpad nav keys arrive as the regular nav VKs but
+    // WITHOUT the extended-key flag — the genuine arrow/nav cluster sets
+    // MASK_EXTENDED. Use that to turn only the non-extended ones into KEY_PAD_*.
+    // Operators (+ - * /) and numpad Enter are deliberately left on their normal
+    // KEY_* codes (see the numpad-map construction above and LLKeyboardSDL).
+    if (!(mask & MASK_EXTENDED))
+    {
+        switch (*translated_key)
+        {
+            case KEY_LEFT:      *translated_key = KEY_PAD_LEFT;  break;
+            case KEY_RIGHT:     *translated_key = KEY_PAD_RIGHT; break;
+            case KEY_UP:        *translated_key = KEY_PAD_UP;    break;
+            case KEY_DOWN:      *translated_key = KEY_PAD_DOWN;  break;
+            case KEY_HOME:      *translated_key = KEY_PAD_HOME;  break;
+            case KEY_END:       *translated_key = KEY_PAD_END;   break;
+            case KEY_PAGE_UP:   *translated_key = KEY_PAD_PGUP;  break;
+            case KEY_PAGE_DOWN: *translated_key = KEY_PAD_PGDN;  break;
+            case KEY_INSERT:    *translated_key = KEY_PAD_INS;   break;
+            case KEY_DELETE:    *translated_key = KEY_PAD_DEL;   break;
+            default: break;
+        }
+    }
+    return success;
 }
 
 U16  LLKeyboardWin32::inverseTranslateExtendedKey(const KEY translated_key)
 {
     // if numlock is on, then we need to translate KEY_PAD_FOO to the corresponding number pad number
-    if(GetKeyState(VK_NUMLOCK) & 1)
+    if((mNumpadDistinct == ND_NUMLOCK_ON) && (GetKeyState(VK_NUMLOCK) & 1))
     {
         std::map<KEY, U16>::iterator iter = mInvTranslateNumpadMap.find(translated_key);
         if (iter != mInvTranslateNumpadMap.end())

--- a/indra/llwindow/llkeyboardwin32.h
+++ b/indra/llwindow/llkeyboardwin32.h
@@ -54,6 +54,11 @@ protected:
 private:
     std::map<U16, KEY> mTranslateNumpadMap;
     std::map<KEY, U16> mInvTranslateNumpadMap;
+    // The KEY each physical key resolved to on its key-down, replayed on key-up
+    // so press/release stay symmetric across a mid-press NumLock toggle (which
+    // otherwise changes the numpad VK — VK_NUMPAD2 vs VK_DOWN — and leaves the
+    // down KEY's level stuck). Keyed by NumLock-independent scancode, not VK.
+    std::map<U32, KEY> mKeyDownTranslation;
 };
 
 #endif

--- a/indra/llwindow/llmousehandler.h
+++ b/indra/llwindow/llmousehandler.h
@@ -30,6 +30,7 @@
 #include "linden_common.h"
 #include "llrect.h"
 #include "indra_constants.h"
+#include "llscrolldelta.h"
 
 // Mostly-abstract interface.
 // Intended for use via multiple inheritance.
@@ -57,8 +58,8 @@ public:
     virtual bool    handleDoubleClick(S32 x, S32 y, MASK mask) = 0;
 
     virtual bool    handleHover(S32 x, S32 y, MASK mask) = 0;
-    virtual bool    handleScrollWheel(S32 x, S32 y, S32 clicks) = 0;
-    virtual bool    handleScrollHWheel(S32 x, S32 y, S32 clicks) = 0;
+    virtual bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) = 0;
+    virtual bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta) = 0;
     virtual bool    handleToolTip(S32 x, S32 y, MASK mask) = 0;
     virtual const std::string& getName() const = 0;
 

--- a/indra/llwindow/llscrolldelta.h
+++ b/indra/llwindow/llscrolldelta.h
@@ -1,0 +1,57 @@
+/**
+ * @file llscrolldelta.h
+ * @brief LLScrollDelta - high-precision mouse scroll-wheel delta
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifndef LL_SCROLLDELTA_H
+#define LL_SCROLLDELTA_H
+
+#include "stdtypes.h"
+
+// A mouse scroll-wheel delta in detent units, where 1.0 == one classic wheel
+// notch. The sign matches the legacy "clicks" convention (a positive vertical
+// value means "scroll content down"; a positive horizontal value means
+// "scroll content right").
+//
+// Two coherent representations of the same gesture are carried together so each
+// consumer can pick what suits it:
+//   - mClicks  : integer notches that crossed a +/-1 boundary this event,
+//                accumulated in the window backend. This is identical to the
+//                value the pre-precision code delivered, so discrete consumers
+//                (steppers, menus, lists) keep their exact behavior. It is 0 on
+//                the sub-notch events that high-resolution wheels and touchpads
+//                emit between boundary crossings.
+//   - mPrecise : the raw per-event delta, in the same units and sign as
+//                mClicks. Continuous consumers (camera zoom, smooth scrolling)
+//                integrate this for sub-notch precision.
+struct LLScrollDelta
+{
+    LLScrollDelta() = default;
+    LLScrollDelta(S32 clicks, F32 precise) : mClicks(clicks), mPrecise(precise) {}
+
+    S32 mClicks  = 0;
+    F32 mPrecise = 0.f;
+};
+
+#endif // LL_SCROLLDELTA_H

--- a/indra/llwindow/llsdl.cpp
+++ b/indra/llwindow/llsdl.cpp
@@ -144,6 +144,9 @@ void init_sdl(const std::string& app_name)
 
                     // Prevent popup of text overlay when holding movement keys on macos
                     {SDL_HINT_MAC_PRESS_AND_HOLD, "0"},
+
+                    // Momentum scrolling on macos is desirable for mac touchpads
+                    {SDL_HINT_MAC_SCROLL_MOMENTUM, "1"},
             };
 
     for (auto hint: hintList)

--- a/indra/llwindow/llsdl.cpp
+++ b/indra/llwindow/llsdl.cpp
@@ -132,6 +132,15 @@ void init_sdl(const std::string& app_name)
                     // every motion event, and we never want a warp-distance
                     // to land in the camera signal. Don't override.
 
+                    // LOAD-BEARING for numpad support: this is SDL3's default
+                    // value, and it deliberately omits "hide_numpad". With
+                    // "hide_numpad" SDL would pre-fold SDLK_KP_* onto the digit
+                    // row / nav cluster based on NumLock *before* delivering the
+                    // event, which would make NumLock-off numpad keys
+                    // indistinguishable from the real arrow keys and break
+                    // LLKeyboardSDL's numpad-distinct logic (it relies on
+                    // receiving the raw SDLK_KP_* keysym). Do not add
+                    // "hide_numpad" here.
                     {SDL_HINT_KEYCODE_OPTIONS,"french_numbers,latin_letters"},
                     // The viewer renders the IME composition string itself
                     // via LLPreeditor::updatePreedit (see the SDL_EVENT_TEXT_EDITING

--- a/indra/llwindow/llsdl.cpp
+++ b/indra/llwindow/llsdl.cpp
@@ -34,10 +34,19 @@
 
 bool gSDLMainHandled = false;
 
-#ifndef LL_SDL_WINDOW
+// SDL_main.h declares SDL_RegisterApp/SDL_UnregisterApp. SDL_MAIN_HANDLED
+// keeps it declaration-only: the entry-point implementation lives in
+// llappviewersdl.cpp (SDL_MAIN_USE_CALLBACKS) on SDL-window builds.
+#if !LL_SDL_WINDOW || LL_WINDOWS
 #define SDL_MAIN_HANDLED 1
 #include "SDL3/SDL_main.h"
+#endif
 
+#if LL_WINDOWS
+#include "llwin32headers.h" // CS_BYTEALIGNCLIENT / CS_OWNDC
+#endif
+
+#ifndef LL_SDL_WINDOW
 void sdl_logger(void *userdata, int category, SDL_LogPriority priority, const char *message)
 {
     switch (priority)

--- a/indra/llwindow/llwindowcallbacks.cpp
+++ b/indra/llwindow/llwindowcallbacks.cpp
@@ -132,11 +132,11 @@ void LLWindowCallbacks::handleMouseDragged(LLWindow *window, const LLCoordGL pos
 {
 }
 
-void LLWindowCallbacks::handleScrollWheel(LLWindow *window, S32 clicks)
+void LLWindowCallbacks::handleScrollWheel(LLWindow *window, LLScrollDelta delta)
 {
 }
 
-void LLWindowCallbacks::handleScrollHWheel(LLWindow *window, S32 clicks)
+void LLWindowCallbacks::handleScrollHWheel(LLWindow *window, LLScrollDelta delta)
 {
 }
 

--- a/indra/llwindow/llwindowcallbacks.h
+++ b/indra/llwindow/llwindowcallbacks.h
@@ -27,6 +27,7 @@
 #define LLWINDOWCALLBACKS_H
 
 #include "llcoord.h"
+#include "llscrolldelta.h"
 class LLWindow;
 
 class LLWindowCallbacks
@@ -56,8 +57,8 @@ public:
     virtual bool handleActivateApp(LLWindow *window, bool activating);
     virtual void handleMouseMove(LLWindow *window,  LLCoordGL pos, MASK mask);
     virtual void handleMouseDragged(LLWindow *window,  LLCoordGL pos, MASK mask);
-    virtual void handleScrollWheel(LLWindow *window,  S32 clicks);
-    virtual void handleScrollHWheel(LLWindow *window,  S32 clicks);
+    virtual void handleScrollWheel(LLWindow *window,  LLScrollDelta delta);
+    virtual void handleScrollHWheel(LLWindow *window,  LLScrollDelta delta);
     virtual void handleResize(LLWindow *window,  S32 width,  S32 height);
     virtual void handleFocus(LLWindow *window);
     virtual void handleFocusLost(LLWindow *window);

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -2108,22 +2108,22 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // amplifying sub-tick noise into spurious scroll events the way
             // llfloor would for negative residue.
             const S32 iy = lltrunc(mScrollWheelAccumY);
-            if (iy != 0)
+            mScrollWheelAccumY -= (F32)iy;
+            if (iy != 0 || event.wheel.y != 0.f)
             {
-                mScrollWheelAccumY -= (F32)iy;
-                mCallbacks->handleScrollWheel(this, -iy);
+                mCallbacks->handleScrollWheel(this, LLScrollDelta(-iy, -event.wheel.y));
             }
             const S32 ix = lltrunc(mScrollWheelAccumX);
-            if (ix != 0)
+            mScrollWheelAccumX -= (F32)ix;
+            if (ix != 0 || event.wheel.x != 0.f)
             {
-                mScrollWheelAccumX -= (F32)ix;
                 // Win32 sends WM_MOUSEHWHEEL's HIWORD (+=right) directly with
                 // no sign flip (llwindowwin32.cpp:2929: `h_delta / WHEEL_DELTA`).
                 // SDL3 `event.wheel.x` follows the same +=right convention, so
                 // forward unmodified. Only the Y axis negates to match
                 // Win32's vertical convention ("+ clicks = scroll content
                 // down" — see the line just above).
-                mCallbacks->handleScrollHWheel(this, ix);
+                mCallbacks->handleScrollHWheel(this, LLScrollDelta(ix, event.wheel.x));
             }
             break;
         }

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -587,16 +587,28 @@ bool LLWindowSDL::createContext(int x, int y, int width, int height, int bits, b
     return true;
 }
 
-void LLWindowSDL::refreshMinSizePixelShadow()
+void LLWindowSDL::refreshPixelMetrics()
 {
-    if (!mWindow || mMinWindowWidth <= 0 || mMinWindowHeight <= 0)
+    if (!mWindow)
     {
         return;
     }
     const float density = SDL_GetWindowPixelDensity(mWindow);
-    const float scale = density > 0.f ? density : 1.f;
-    mMinWindowWidthPx = (U32)(mMinWindowWidth * scale);
-    mMinWindowHeightPx = (U32)(mMinWindowHeight * scale);
+    mCachedPixelDensity = density > 0.f ? density : 1.f;
+    S32 height_pixels = 0;
+    SDL_GetWindowSizeInPixels(mWindow, nullptr, &height_pixels);
+    mCachedWindowHeightPx = height_pixels;
+}
+
+void LLWindowSDL::refreshMinSizePixelShadow()
+{
+    refreshPixelMetrics();
+    if (!mWindow || mMinWindowWidth <= 0 || mMinWindowHeight <= 0)
+    {
+        return;
+    }
+    mMinWindowWidthPx = (U32)(mMinWindowWidth * mCachedPixelDensity);
+    mMinWindowHeightPx = (U32)(mMinWindowHeight * mCachedPixelDensity);
 }
 
 // Opaque handle returned from createSharedContext() and passed back to
@@ -1805,8 +1817,14 @@ bool LLWindowSDL::convertCoords(LLCoordGL from, LLCoordWindow *to)
     // Both spaces are window-relative PIXEL units. Y-flip using the pixel
     // window height; the X axis is identity. Y-down LLCoordWindow has
     // mY = 0 at the top, Y-up LLCoordGL has mY = 0 at the bottom.
-    S32 height_pixels = 0;
-    SDL_GetWindowSizeInPixels(mWindow, nullptr, &height_pixels);
+    // Use the cached pixel height (refreshed on every resize/DPI change) to skip
+    // a GetClientRect syscall on the per-event conversion path; fall back to a
+    // live query before the first refresh (height still 0).
+    S32 height_pixels = mCachedWindowHeightPx;
+    if (height_pixels <= 0)
+    {
+        SDL_GetWindowSizeInPixels(mWindow, nullptr, &height_pixels);
+    }
 
     to->mX = from.mX;
     to->mY = height_pixels - from.mY - 1;
@@ -1819,9 +1837,13 @@ bool LLWindowSDL::convertCoords(LLCoordWindow from, LLCoordGL* to)
     if (!to || !mWindow)
         return false;
 
-    // Inverse of the above — Y-flip in pixels, X is identity.
-    S32 height_pixels = 0;
-    SDL_GetWindowSizeInPixels(mWindow, nullptr, &height_pixels);
+    // Inverse of the above — Y-flip in pixels, X is identity. Cached height (see
+    // the forward conversion above) with a live fallback before the first refresh.
+    S32 height_pixels = mCachedWindowHeightPx;
+    if (height_pixels <= 0)
+    {
+        SDL_GetWindowSizeInPixels(mWindow, nullptr, &height_pixels);
+    }
 
     to->mX = from.mX;
     to->mY = height_pixels - from.mY - 1;
@@ -2058,8 +2080,9 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // PIXEL units so LLCoordWindow stays in the same unit as
             // mWindowRectRaw and the rest of the viewer's pixel-based hit
             // testing — see the coord-space contract below convertCoords.
-            const float density = SDL_GetWindowPixelDensity(mWindow);
-            const float scale = density > 0.f ? density : 1.f;
+            // Cached density (refreshed on resize/DPI change) — avoids a
+            // GetClientRect syscall per motion event (up to the mouse poll rate).
+            const float scale = mCachedPixelDensity;
 
             // Always accumulate the per-event relative motion (xrel/yrel) so
             // getCursorDelta() — drained once per frame from
@@ -2233,8 +2256,7 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
                                        || event.button.which == SDL_PEN_MOUSEID);
 
             // Scale screen-coord event coords up to PIXEL units for LLCoordWindow.
-            const float density = SDL_GetWindowPixelDensity(mWindow);
-            const float scale = density > 0.f ? density : 1.f;
+            const float scale = mCachedPixelDensity; // cached; see refreshPixelMetrics
             LLCoordWindow winCoord(llfloor(event.button.x * scale),
                                    llfloor(event.button.y * scale));
             LLCoordGL openGlCoord;
@@ -2275,8 +2297,7 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             mAbsoluteCursorPosition = (event.button.which == SDL_TOUCH_MOUSEID
                                        || event.button.which == SDL_PEN_MOUSEID);
 
-            const float density = SDL_GetWindowPixelDensity(mWindow);
-            const float scale = density > 0.f ? density : 1.f;
+            const float scale = mCachedPixelDensity; // cached; see refreshPixelMetrics
             LLCoordWindow winCoord(llfloor(event.button.x * scale),
                                    llfloor(event.button.y * scale));
             LLCoordGL openGlCoord;
@@ -2513,12 +2534,13 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
         case SDL_EVENT_WINDOW_RESIZED:
         {
             LL_INFOS() << "Handling a resize event: " << event.window.data1 << "x" << event.window.data2 << LL_ENDL;
-            // Guard pixel_density against the 0.f the SDL backend can return
-            // briefly during display-change races. Without this, the multiply
-            // below would zero out width/height and we'd call handleResize
-            // with a degenerate 0x0 rectangle.
-            const F32 raw_density = SDL_GetWindowPixelDensity(mWindow);
-            const F32 pixel_density = raw_density > 0.f ? raw_density : 1.f;
+            // Window size changed: refresh the cached pixel metrics the input
+            // handlers and convertCoords read, and reuse the density here.
+            // refreshPixelMetrics clamps it > 0, covering the 0.f the SDL backend
+            // can briefly return during display-change races (which would
+            // otherwise zero width/height into a degenerate handleResize).
+            refreshPixelMetrics();
+            const F32 pixel_density = mCachedPixelDensity;
             // mMinWindowWidth/Height are 0 until setMinSize runs, so llmax can't
             // keep these positive this early. Floor to 1px so a 0-dimension
             // resize (some WMs emit one mid-drag / on un-maximize) never reaches
@@ -2538,6 +2560,9 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // so the clamp has to use the PIXEL-unit minimum shadow — the
             // screen-coord mMinWindowWidth/Height would under-clamp on HiDPI.
             LL_INFOS() << "Handling a pixel-size event: " << event.window.data1 << "x" << event.window.data2 << LL_ENDL;
+            // Back-buffer dimensions changed; refresh the cached pixel height
+            // convertCoords reads.
+            refreshPixelMetrics();
             // Floor to 1px: mMinWindowWidthPx/HeightPx are 0 until setMinSize
             // runs, so a 0-dimension pixel-size event would otherwise pass
             // through as a degenerate 0x0 resize.
@@ -2709,8 +2734,7 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             //   2) DNDA_DROPPED                           -> upload / apply
             //   3) DNDA_STOP_TRACKING                     -> mDragItems cleared
             // event.drop.x/y are screen-coord units; scale to PIXEL units.
-            const float density = SDL_GetWindowPixelDensity(mWindow);
-            const float scale = density > 0.f ? density : 1.f;
+            const float scale = mCachedPixelDensity; // cached; see refreshPixelMetrics
             LLCoordWindow winCoord(llfloor(event.drop.x * scale),
                                    llfloor(event.drop.y * scale));
             LLCoordGL openGlCoord;

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -70,6 +70,17 @@ LLWindowSDL::WAYLAND_DATA LLWindowSDL::sWaylandData = {};
 bool LLWindowSDL::sUseMultGL = false;
 #endif
 
+#if LL_WINDOWS
+#define DIRECTINPUT_VERSION 0x0800
+#include <dinput.h>
+#include "lldxhardware.h"
+
+// DirectInput8 interface for llviewerjoystick / SpaceNavigator. Created once
+// in the LLWindowSDL constructor; only needs the process module handle, not
+// the window, so the SDL backend can provide the same access LLWindowWin32 does.
+static LPDIRECTINPUT8 gSDLDirectInput8 = nullptr;
+#endif
+
 bool gHiDPISupport = true;
 
 const S32 MAX_NUM_RESOLUTIONS = 200;
@@ -106,6 +117,19 @@ LLWindowSDL::LLWindowSDL(LLWindowCallbacks* callbacks,
     gKeyboard = new LLKeyboardSDL();
     gKeyboard->setCallbacks(callbacks);
 
+#if LL_WINDOWS
+    // Init Direct Input - needed for joystick / Spacemouse (see llviewerjoystick).
+    if (!gSDLDirectInput8)
+    {
+        LPDIRECTINPUT8 di8_interface = nullptr;
+        if (DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION,
+                               IID_IDirectInput8, (LPVOID*)&di8_interface, nullptr) == DI_OK)
+        {
+            gSDLDirectInput8 = di8_interface;
+        }
+    }
+#endif
+
     // Assume 4:3 aspect ratio until we know better
     mNativeAspectRatio = 1024.f / 768.f;
 
@@ -140,6 +164,10 @@ LLWindowSDL::LLWindowSDL(LLWindowCallbacks* callbacks,
     {
         gGLManager.initWGL();
         gGLManager.initGL();
+#if LL_WINDOWS
+        // GL didn't always report a VRAM budget (notably Intel iGPUs); ask DXGI.
+        LLDXHardware::updateVRAMBudgetFromDXGI();
+#endif
 
         //start with arrow cursor
         initCursors();
@@ -149,11 +177,12 @@ LLWindowSDL::LLWindowSDL(LLWindowCallbacks* callbacks,
     stop_glerror();
 }
 
-#if !LL_DARWIN
-// The BMP cursor/icon tree (res-sdl/) is only shipped in the Linux bundle. On
-// macOS we load cursors from cursors_mac/*.tif (see makeSDLCursorFromMacTIF
-// below), so this helper would be unused there — and the build is -Werror on
-// unused static functions.
+#if LL_LINUX
+// The BMP cursor/icon tree (res-sdl/) is only shipped in the Linux bundle.
+// macOS loads cursors from cursors_mac/*.tif (makeSDLCursorFromMacTIF) and
+// Windows from the exe's embedded .cur resources (makeSDLCursorFromWin32), so
+// this helper would be unused on those platforms — and the build is -Werror
+// on unused static functions.
 static SDL_Surface *Load_BMP_Resource(const char *basename)
 {
     const int PATH_BUFFER_SIZE=1000;
@@ -169,7 +198,7 @@ static SDL_Surface *Load_BMP_Resource(const char *basename)
 
     return SDL_LoadBMP(path_buffer);
 }
-#endif // !LL_DARWIN
+#endif // LL_LINUX
 
 void LLWindowSDL::setTitle(const std::string title)
 {
@@ -538,6 +567,12 @@ bool LLWindowSDL::createContext(int x, int y, int width, int height, int bits, b
     // different density (after switchContext). Recompute now that mWindow
     // reflects the active display.
     refreshMinSizePixelShadow();
+
+#if LL_WINDOWS
+    // Hook WM_COPYDATA on the native HWND for second-instance SLURL hand-off.
+    installWin32Subclass();
+#endif
+
     return true;
 }
 
@@ -653,6 +688,9 @@ bool LLWindowSDL::switchContext(bool fullscreen, const LLCoordScreen &size, bool
         {
             gGLManager.initWGL();
             gGLManager.initGL();
+#if LL_WINDOWS
+            LLDXHardware::updateVRAMBudgetFromDXGI();
+#endif
 
             //start with arrow cursor
             initCursors();
@@ -694,6 +732,11 @@ void LLWindowSDL::destroyContext()
         }
         mDeadOSRWindows.clear();
     }
+
+#if LL_WINDOWS
+    // Unhook WM_COPYDATA before SDL tears the HWND down.
+    removeWin32Subclass();
+#endif
 
     // Stop unicode input — paired with the SDL_StartTextInput in createContext().
     // Guard against the early-failure path where SDL_CreateWindowWithProperties
@@ -786,6 +829,14 @@ LLWindowSDL::~LLWindowSDL()
     destroyContext();
 
     delete[] mSupportedResolutions;
+
+#if LL_WINDOWS
+    if (gSDLDirectInput8)
+    {
+        gSDLDirectInput8->Release();
+        gSDLDirectInput8 = nullptr;
+    }
+#endif
 
     gWindowImplementation = nullptr;
 }
@@ -2207,8 +2258,8 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // with a degenerate 0x0 rectangle.
             const F32 raw_density = SDL_GetWindowPixelDensity(mWindow);
             const F32 pixel_density = raw_density > 0.f ? raw_density : 1.f;
-            S32 width = llmax(event.window.data1, (S32)mMinWindowWidth) * pixel_density;
-            S32 height = llmax(event.window.data2, (S32)mMinWindowHeight) * pixel_density;
+            S32 width = (S32)(llmax(event.window.data1, (S32)mMinWindowWidth) * pixel_density);
+            S32 height = (S32)(llmax(event.window.data2, (S32)mMinWindowHeight) * pixel_density);
 
             mCallbacks->handleResize(this, width, height);
             break;
@@ -2539,7 +2590,7 @@ static SDL_Cursor *makeSDLCursorFromMacTIF(const char *basename, int hotx, int h
 }
 #endif // LL_DARWIN
 
-#if !LL_DARWIN
+#if LL_LINUX
 static SDL_Cursor *makeSDLCursorFromBMP(const char *filename, int hotx, int hoty)
 {
     SDL_Surface *bmpsurface = Load_BMP_Resource(filename);
@@ -2621,7 +2672,192 @@ static SDL_Cursor *makeSDLCursorFromBMP(const char *filename, int hotx, int hoty
     }
     return sdlcursor;
 }
-#endif // !LL_DARWIN
+#endif // LL_LINUX
+
+#if LL_WINDOWS
+// Convert one of the viewer's embedded Win32 cursor resources (the same
+// branded .cur/.ani assets the native backend loads in
+// LLWindowWin32::initCursors) into an SDL color cursor. The hot-spot is taken
+// from the resource itself via GetIconInfo, so — unlike the BMP path — there
+// is no hand-maintained hot-spot table to keep in sync. Returns nullptr if the
+// resource is missing or can't be converted, letting initCursors fall back to
+// the SDL system arrow.
+// Read a GDI bitmap as `rows` of top-down 32bpp BGRA into `out`. Used for both
+// the colour bitmap and the (1bpp or 8bpp) mask — GetDIBits converts whatever
+// the source depth is to 32bpp, so monochrome masks come back as black(0)/
+// white(0xFFFFFF) pixels we can test a single byte of.
+static bool win32ReadDIB32(HBITMAP hbm, int width, int rows, std::vector<U8>& out)
+{
+    out.assign((size_t)width * rows * 4, 0);
+    BITMAPINFO bi = {};
+    bi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth       = width;
+    bi.bmiHeader.biHeight      = -rows; // negative => top-down rows
+    bi.bmiHeader.biPlanes      = 1;
+    bi.bmiHeader.biBitCount    = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+    HDC hdc = GetDC(nullptr);
+    const bool ok = GetDIBits(hdc, hbm, 0, rows, out.data(), &bi, DIB_RGB_COLORS) != 0;
+    ReleaseDC(nullptr, hdc);
+    return ok;
+}
+
+// Convert one of the viewer's embedded Win32 cursor resources (the same
+// branded .cur/.ani assets the native backend loads in
+// LLWindowWin32::initCursors) into an SDL color cursor. The hot-spot is taken
+// from the resource itself via GetIconInfo, so — unlike the BMP path — there
+// is no hand-maintained hot-spot table to keep in sync. Returns nullptr if the
+// resource is missing or can't be converted, letting initCursors fall back to
+// the SDL system arrow.
+static SDL_Cursor *makeSDLCursorFromWin32(const char *resource_name)
+{
+    HMODULE module = GetModuleHandle(nullptr);
+    // LR_DEFAULTCOLOR matches LLWindowWin32::loadColorCursor and also works for
+    // the monochrome resources LoadCursor would otherwise handle. LR_SHARED so
+    // we don't have to DestroyCursor an exe-embedded resource.
+    HCURSOR hcur = (HCURSOR)LoadImageA(module, resource_name, IMAGE_CURSOR,
+                                       0, 0, LR_DEFAULTCOLOR | LR_SHARED);
+    if (!hcur)
+    {
+        LL_WARNS() << "Cursor resource not found: " << resource_name << LL_ENDL;
+        return nullptr;
+    }
+
+    ICONINFO ii = {};
+    if (!GetIconInfo(hcur, &ii))
+    {
+        LL_WARNS() << "GetIconInfo failed for cursor " << resource_name
+                   << " (err " << GetLastError() << ")" << LL_ENDL;
+        return nullptr;
+    }
+    // GetIconInfo hands back *copies* of the bitmaps that we own and must free.
+    // For a 1bpp monochrome cursor hbmColor is NULL and hbmMask is double-height
+    // (AND mask stacked over XOR mask); colour cursors (8/32bpp) carry hbmColor.
+    HBITMAP hbmColor = ii.hbmColor;
+    HBITMAP hbmMask  = ii.hbmMask;
+    const bool monochrome = (hbmColor == nullptr);
+
+    SDL_Cursor *result = nullptr;
+    BITMAP bm = {};
+    HBITMAP dim_src = monochrome ? hbmMask : hbmColor;
+    if (dim_src && GetObject(dim_src, sizeof(bm), &bm) && bm.bmWidth > 0 && bm.bmHeight > 0)
+    {
+        const int width  = bm.bmWidth;
+        const int height = monochrome ? bm.bmHeight / 2 : bm.bmHeight;
+        const size_t count = (size_t)width * height;
+
+        std::vector<U8> rgba(count * 4, 0); // final R,G,B,A handed to SDL
+        bool built = false;
+
+        if (!monochrome)
+        {
+            std::vector<U8> color, mask;
+            const bool got_color = win32ReadDIB32(hbmColor, width, height, color);
+            const bool got_mask  = hbmMask && win32ReadDIB32(hbmMask, width, height, mask);
+            if (got_color)
+            {
+                // 32bpp .cur files carry a real per-pixel alpha channel; 8bpp
+                // ones leave it zero and express transparency via the AND mask.
+                bool has_alpha = false;
+                for (size_t i = 0; i < count; ++i)
+                {
+                    if (color[i * 4 + 3] != 0) { has_alpha = true; break; }
+                }
+                for (size_t i = 0; i < count; ++i)
+                {
+                    const U8 b = color[i * 4 + 0];
+                    const U8 g = color[i * 4 + 1];
+                    const U8 r = color[i * 4 + 2];
+                    U8 a = color[i * 4 + 3];
+                    if (!has_alpha)
+                    {
+                        // AND mask: white (set) => transparent, black => opaque.
+                        a = (got_mask && mask[i * 4 + 0]) ? 0 : 255;
+                    }
+                    rgba[i * 4 + 0] = r;
+                    rgba[i * 4 + 1] = g;
+                    rgba[i * 4 + 2] = b;
+                    rgba[i * 4 + 3] = a;
+                }
+                built = true;
+            }
+            else
+            {
+                LL_WARNS() << "GetDIBits failed for cursor " << resource_name << LL_ENDL;
+            }
+        }
+        else
+        {
+            // 1bpp: hbmMask is AND mask (top half) over XOR mask (bottom half).
+            //   AND=1,XOR=0 => transparent;  AND=0,XOR=1 => white;
+            //   AND=0,XOR=0 => black;  AND=1,XOR=1 => invert screen (approximated
+            //   as opaque black — none of the viewer's cursors rely on invert).
+            std::vector<U8> mask;
+            if (win32ReadDIB32(hbmMask, width, height * 2, mask))
+            {
+                for (size_t i = 0; i < count; ++i)
+                {
+                    const bool and_bit = mask[i * 4] != 0;            // top half
+                    const bool xor_bit = mask[(count + i) * 4] != 0;  // bottom half
+                    U8 r, g, b, a;
+                    if (and_bit && !xor_bit)      { r = g = b = 0;   a = 0;   }
+                    else if (!and_bit && xor_bit) { r = g = b = 255; a = 255; }
+                    else                          { r = g = b = 0;   a = 255; }
+                    rgba[i * 4 + 0] = r;
+                    rgba[i * 4 + 1] = g;
+                    rgba[i * 4 + 2] = b;
+                    rgba[i * 4 + 3] = a;
+                }
+                built = true;
+            }
+            else
+            {
+                LL_WARNS() << "GetDIBits failed for monochrome cursor " << resource_name << LL_ENDL;
+            }
+        }
+
+        if (built)
+        {
+            SDL_Surface *surf = SDL_CreateSurface(width, height, SDL_PIXELFORMAT_RGBA32);
+            if (surf)
+            {
+                const bool must_lock = SDL_MUSTLOCK(surf);
+                if (!must_lock || SDL_LockSurface(surf))
+                {
+                    for (int y = 0; y < height; ++y)
+                    {
+                        memcpy((U8*)surf->pixels + (size_t)y * surf->pitch,
+                               rgba.data() + (size_t)y * width * 4,
+                               (size_t)width * 4);
+                    }
+                    if (must_lock)
+                    {
+                        SDL_UnlockSurface(surf);
+                    }
+
+                    int hotx = llclamp((int)ii.xHotspot, 0, width - 1);
+                    int hoty = llclamp((int)ii.yHotspot, 0, height - 1);
+                    result = SDL_CreateColorCursor(surf, hotx, hoty);
+                    if (!result)
+                    {
+                        LL_WARNS() << "SDL_CreateColorCursor failed for " << resource_name
+                                   << ": " << SDL_GetError() << LL_ENDL;
+                    }
+                }
+                SDL_DestroySurface(surf);
+            }
+        }
+    }
+    else
+    {
+        LL_WARNS() << "Cursor " << resource_name << " has no usable bitmap." << LL_ENDL;
+    }
+
+    if (hbmColor) DeleteObject(hbmColor);
+    if (hbmMask)  DeleteObject(hbmMask);
+    return result;
+}
+#endif // LL_WINDOWS
 
 void LLWindowSDL::updateCursor()
 {
@@ -2706,6 +2942,42 @@ void LLWindowSDL::initCursors()
     mSDLCursors[UI_CURSOR_TOOLPATHFINDING_PATH_END] = makeSDLCursorFromMacTIF("UI_CURSOR_PATHFINDING_END.tif", 16, 16);
     mSDLCursors[UI_CURSOR_TOOLPATHFINDING_PATH_END_ADD] = makeSDLCursorFromMacTIF("UI_CURSOR_PATHFINDING_END_ADD.tif", 16, 16);
     mSDLCursors[UI_CURSOR_TOOLNO] = makeSDLCursorFromMacTIF("UI_CURSOR_NO.tif", 8, 8);
+#elif LL_WINDOWS
+    // Load the branded cursors from the exe's embedded .cur resources — the
+    // same resource names LLWindowWin32::initCursors uses. Hot-spots come from
+    // the resources themselves (GetIconInfo), so there's no hand-tuned table.
+    mSDLCursors[UI_CURSOR_TOOLGRAB] = makeSDLCursorFromWin32("TOOLGRAB");
+    mSDLCursors[UI_CURSOR_TOOLLAND] = makeSDLCursorFromWin32("TOOLLAND");
+    mSDLCursors[UI_CURSOR_TOOLFOCUS] = makeSDLCursorFromWin32("TOOLFOCUS");
+    mSDLCursors[UI_CURSOR_TOOLCREATE] = makeSDLCursorFromWin32("TOOLCREATE");
+    mSDLCursors[UI_CURSOR_ARROWDRAG] = makeSDLCursorFromWin32("ARROWDRAG");
+    mSDLCursors[UI_CURSOR_ARROWCOPY] = makeSDLCursorFromWin32("ARROWCOPY");
+    mSDLCursors[UI_CURSOR_ARROWDRAGMULTI] = makeSDLCursorFromWin32("ARROWDRAGMULTI");
+    mSDLCursors[UI_CURSOR_ARROWCOPYMULTI] = makeSDLCursorFromWin32("ARROWCOPYMULTI");
+    mSDLCursors[UI_CURSOR_NOLOCKED] = makeSDLCursorFromWin32("NOLOCKED");
+    mSDLCursors[UI_CURSOR_ARROWLOCKED] = makeSDLCursorFromWin32("ARROWLOCKED");
+    mSDLCursors[UI_CURSOR_GRABLOCKED] = makeSDLCursorFromWin32("GRABLOCKED");
+    mSDLCursors[UI_CURSOR_TOOLTRANSLATE] = makeSDLCursorFromWin32("TOOLTRANSLATE");
+    mSDLCursors[UI_CURSOR_TOOLROTATE] = makeSDLCursorFromWin32("TOOLROTATE");
+    mSDLCursors[UI_CURSOR_TOOLSCALE] = makeSDLCursorFromWin32("TOOLSCALE");
+    mSDLCursors[UI_CURSOR_TOOLCAMERA] = makeSDLCursorFromWin32("TOOLCAMERA");
+    mSDLCursors[UI_CURSOR_TOOLPAN] = makeSDLCursorFromWin32("TOOLPAN");
+    mSDLCursors[UI_CURSOR_TOOLZOOMIN] = makeSDLCursorFromWin32("TOOLZOOMIN");
+    mSDLCursors[UI_CURSOR_TOOLZOOMOUT] = makeSDLCursorFromWin32("TOOLZOOMOUT");
+    mSDLCursors[UI_CURSOR_TOOLPICKOBJECT3] = makeSDLCursorFromWin32("TOOLPICKOBJECT3");
+    mSDLCursors[UI_CURSOR_TOOLPLAY] = makeSDLCursorFromWin32("TOOLPLAY");
+    mSDLCursors[UI_CURSOR_TOOLPAUSE] = makeSDLCursorFromWin32("TOOLPAUSE");
+    mSDLCursors[UI_CURSOR_TOOLMEDIAOPEN] = makeSDLCursorFromWin32("TOOLMEDIAOPEN");
+    mSDLCursors[UI_CURSOR_PIPETTE] = makeSDLCursorFromWin32("TOOLPIPETTE");
+    mSDLCursors[UI_CURSOR_TOOLSIT] = makeSDLCursorFromWin32("TOOLSIT");
+    mSDLCursors[UI_CURSOR_TOOLBUY] = makeSDLCursorFromWin32("TOOLBUY");
+    mSDLCursors[UI_CURSOR_TOOLOPEN] = makeSDLCursorFromWin32("TOOLOPEN");
+    mSDLCursors[UI_CURSOR_TOOLPATHFINDING] = makeSDLCursorFromWin32("TOOLPATHFINDING");
+    mSDLCursors[UI_CURSOR_TOOLPATHFINDING_PATH_START] = makeSDLCursorFromWin32("TOOLPATHFINDINGPATHSTART");
+    mSDLCursors[UI_CURSOR_TOOLPATHFINDING_PATH_START_ADD] = makeSDLCursorFromWin32("TOOLPATHFINDINGPATHSTARTADD");
+    mSDLCursors[UI_CURSOR_TOOLPATHFINDING_PATH_END] = makeSDLCursorFromWin32("TOOLPATHFINDINGPATHEND");
+    mSDLCursors[UI_CURSOR_TOOLPATHFINDING_PATH_END_ADD] = makeSDLCursorFromWin32("TOOLPATHFINDINGPATHENDADD");
+    mSDLCursors[UI_CURSOR_TOOLNO] = makeSDLCursorFromWin32("TOOLNO");
 #else
     mSDLCursors[UI_CURSOR_TOOLGRAB] = makeSDLCursorFromBMP("lltoolgrab.BMP",2,13);
     mSDLCursors[UI_CURSOR_TOOLLAND] = makeSDLCursorFromBMP("lltoolland.BMP",1,6);
@@ -3079,6 +3351,100 @@ void* LLWindowSDL::getPlatformWindow()
     }
     return ret;
 }
+
+#if LL_WINDOWS
+void LLWindowSDL::installWin32Subclass()
+{
+    if (mPrevWndProc) // already installed
+        return;
+
+    HWND hwnd = (HWND)getPlatformWindow();
+    if (!hwnd)
+        return;
+
+    mWin32Hwnd = hwnd;
+    mPrevWndProc = (WNDPROC)SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
+                                              (LONG_PTR)&LLWindowSDL::win32WndProc);
+}
+
+void LLWindowSDL::removeWin32Subclass()
+{
+    if (mWin32Hwnd && mPrevWndProc)
+    {
+        SetWindowLongPtrW(mWin32Hwnd, GWLP_WNDPROC, (LONG_PTR)mPrevWndProc);
+    }
+    mWin32Hwnd = nullptr;
+    mPrevWndProc = nullptr;
+}
+
+// SDL pumps the Win32 message queue on the main thread, so a cross-process
+// SendMessage(WM_COPYDATA) is dispatched here synchronously on the main
+// thread — no cross-thread post needed (unlike LLWindowWin32, whose WndProc
+// runs on its own window thread). Everything else chains to SDL's WndProc so
+// the window keeps working normally.
+LRESULT CALLBACK LLWindowSDL::win32WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
+{
+    LLWindowSDL* self = gWindowImplementation;
+
+    if (msg == WM_COPYDATA && self)
+    {
+        // received a URL from a second instance (see sendURLToOtherInstance).
+        PCOPYDATASTRUCT cds = (PCOPYDATASTRUCT)lparam;
+        // The only downstream consumer (LLViewerWindow::handleDataCopy) treats
+        // the payload as a C string. Reject oversized or empty messages and
+        // guarantee NUL-termination so a misbehaving sender can't force a huge
+        // alloc or trigger an OOB read.
+        constexpr DWORD MAX_WM_COPYDATA_BYTES = 64 * 1024;
+        if (cds && cds->lpData && cds->cbData != 0 && cds->cbData <= MAX_WM_COPYDATA_BYTES)
+        {
+            const DWORD cb = cds->cbData;
+            U8* data = new U8[cb + 1];
+            memcpy(data, cds->lpData, cb);
+            data[cb] = 0;
+            self->handleDataCopy((S32)cds->dwData, data);
+            delete[] data;
+        }
+        return TRUE;
+    }
+
+    WNDPROC prev = (self && self->mWin32Hwnd == hwnd) ? self->mPrevWndProc : nullptr;
+    if (prev)
+        return CallWindowProcW(prev, hwnd, msg, wparam, lparam);
+    return DefWindowProcW(hwnd, msg, wparam, lparam);
+}
+
+void LLWindowSDL::handleDataCopy(S32 data_type, void* data)
+{
+    if (mCallbacks)
+    {
+        mCallbacks->handleDataCopy(this, data_type, data);
+    }
+}
+
+void* LLWindowSDL::getDirectInput8()
+{
+    return &gSDLDirectInput8;
+}
+
+bool LLWindowSDL::getInputDevices(U32 device_type_filter,
+                                  std::function<bool(std::string&, LLSD&, void*)> osx_callback,
+                                  void* di8_devices_callback,
+                                  void* userdata)
+{
+    if (gSDLDirectInput8 != nullptr)
+    {
+        // Enumerate devices
+        HRESULT status = gSDLDirectInput8->EnumDevices(
+            (DWORD)device_type_filter,
+            (LPDIENUMDEVICESCALLBACK)di8_devices_callback,
+            (LPVOID*)userdata,
+            DIEDFL_ATTACHEDONLY);
+
+        return status == DI_OK;
+    }
+    return false;
+}
+#endif // LL_WINDOWS
 
 void LLWindowSDL::bringToFront()
 {

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -81,6 +81,17 @@ bool LLWindowSDL::sUseMultGL = false;
 static LPDIRECTINPUT8 gSDLDirectInput8 = nullptr;
 #endif
 
+// Native shared-GL-context creation (see createSharedContext). The GLX/EGL
+// entry points are resolved at runtime via SDL_GL_GetProcAddress /
+// SDL_EGL_GetProcAddress (the viewer doesn't link libGL/libEGL directly under
+// SDL), so we only need the platform types and tokens here.
+#if LL_X11
+#include <GL/glx.h>
+#endif
+#if LL_WAYLAND
+#include <EGL/egl.h>
+#endif
+
 bool gHiDPISupport = true;
 
 const S32 MAX_NUM_RESOLUTIONS = 200;
@@ -277,14 +288,13 @@ bool LLWindowSDL::createContext(int x, int y, int width, int height, int bits, b
 
     // Setup default backing colors
     GLint redBits{8}, greenBits{8}, blueBits{8}, alphaBits{8};
-    GLint depthBits{24}, stencilBits{8};
+    GLint depthBits{ 24 };
 
     SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   redBits);
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, greenBits);
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,  blueBits);
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, alphaBits);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, depthBits);
-    SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, stencilBits);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
     // Multi-sample anti-aliasing. Driver may quietly downgrade to 0/2/4/8
@@ -498,7 +508,6 @@ bool LLWindowSDL::createContext(int x, int y, int width, int height, int bits, b
     SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &blueBits);
     SDL_GL_GetAttribute(SDL_GL_ALPHA_SIZE, &alphaBits);
     SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &depthBits);
-    SDL_GL_GetAttribute(SDL_GL_STENCIL_SIZE, &stencilBits);
 
     LL_INFOS() << "GL buffer:" << LL_ENDL;
     LL_INFOS() << "  Red Bits " << S32(redBits) << LL_ENDL;
@@ -506,7 +515,6 @@ bool LLWindowSDL::createContext(int x, int y, int width, int height, int bits, b
     LL_INFOS() << "  Blue Bits " << S32(blueBits) << LL_ENDL;
     LL_INFOS() << "  Alpha Bits " << S32(alphaBits) << LL_ENDL;
     LL_INFOS() << "  Depth Bits " << S32(depthBits) << LL_ENDL;
-    LL_INFOS() << "  Stencil Bits " << S32(stencilBits) << LL_ENDL;
 
     GLint colorBits = redBits + greenBits + blueBits + alphaBits;
     if (colorBits < 32)
@@ -588,76 +596,332 @@ void LLWindowSDL::refreshMinSizePixelShadow()
     mMinWindowHeightPx = (U32)(mMinWindowHeight * scale);
 }
 
+// Opaque handle returned from createSharedContext() and passed back to
+// makeContextCurrent()/destroySharedContext(). Carries whatever the platform
+// GL API needs to bind and tear down the context.
+namespace
+{
+    struct LLSDLSharedContext
+    {
+#if LL_WINDOWS
+        HGLRC rc = nullptr;
+        HDC   dc = nullptr;        // main window DC the sibling context binds to
+#elif LL_DARWIN
+        CGLContextObj ctx = nullptr;
+#else // LL_LINUX
+#if LL_X11
+        // X11 / GLX
+        Display*   glx_dpy  = nullptr;
+        GLXContext glx_ctx  = nullptr;
+        GLXPbuffer glx_pbuf = 0;
+#endif
+#if LL_WAYLAND
+        // Wayland / EGL — kept as void* so EGL types stay out of the header
+        void* egl_dpy = nullptr;   // EGLDisplay
+        void* egl_ctx = nullptr;   // EGLContext
+#endif
+#endif
+    };
+
+    // Platform GL teardown for one shared context. No bookkeeping — the caller
+    // owns mSharedContexts and the LLSDLSharedContext allocation.
+    void tearDownNativeSharedContext(LLSDLSharedContext* s)
+    {
+        if (!s) return;
+#if LL_WINDOWS
+        if (s->rc && !wglDeleteContext(s->rc))
+        {
+            LL_WARNS("Window") << "wglDeleteContext(shared) failed: " << GetLastError() << LL_ENDL;
+        }
+#elif LL_DARWIN
+        if (s->ctx)
+        {
+            CGLDestroyContext(s->ctx);
+        }
+#else // LL_LINUX
+#if LL_X11
+        if (s->glx_ctx)
+        {
+            typedef void (*fn_destroyctx)(Display*, GLXContext);
+            typedef void (*fn_destroypb)(Display*, GLXPbuffer);
+            auto glx_destroyctx = (fn_destroyctx)SDL_GL_GetProcAddress("glXDestroyContext");
+            auto glx_destroypb  = (fn_destroypb)SDL_GL_GetProcAddress("glXDestroyPbuffer");
+            if (glx_destroyctx) glx_destroyctx(s->glx_dpy, s->glx_ctx);
+            if (glx_destroypb && s->glx_pbuf) glx_destroypb(s->glx_dpy, s->glx_pbuf);
+        }
+#endif
+#if LL_WAYLAND
+        if (s->egl_ctx)
+        {
+            typedef unsigned int (*fn_destroyctx)(void*, void*);
+            auto egl_destroyctx = (fn_destroyctx)SDL_EGL_GetProcAddress("eglDestroyContext");
+            if (egl_destroyctx) egl_destroyctx(s->egl_dpy, s->egl_ctx);
+        }
+#endif
+#endif
+    }
+}
+
+// Create a GL context that shares object namespace with the main context, for
+// a worker thread (texture upload, VBO streaming). Uses the platform-native GL
+// API behind SDL instead of a hidden carrier SDL_Window — see the header note.
+// Runs on the main thread (the thread that constructs the GL worker pool).
 void* LLWindowSDL::createSharedContext()
 {
-    SDL_PropertiesID props = SDL_CreateProperties();
-    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, "Alchemy Viewer OSR Utility");
-    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, 1);
-    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, 1);
-    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, false);
-    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, true);
-    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIDDEN_BOOLEAN, true);
-    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_FOCUSABLE_BOOLEAN, false);
-    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_UTILITY_BOOLEAN, true);
-    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, gHiDPISupport);
-
-    auto osr_window = SDL_CreateWindowWithProperties(props);
-    if (osr_window == nullptr)
-    {
-        SDL_DestroyProperties(props);
-        return nullptr;
-    }
-    SDL_DestroyProperties(props); // Free properties once window is created
-    SDL_GLContext pContext = SDL_GL_CreateContext(osr_window);
-
-    // Restore the main window's context as current — creating the OSR context
-    // typically leaves the new (or null) context bound. Failure here is rare
-    // but serious: the rest of the frame would render without a valid context.
+    // Bind the main context so the platform "get current" queries below return
+    // the main display / config / share-context, and so the new context shares
+    // object namespace with the right context.
     if (!SDL_GL_MakeCurrent(mWindow, mContext))
     {
-        LL_WARNS() << "SDL_GL_MakeCurrent(main) failed after createSharedContext: "
+        LL_WARNS() << "SDL_GL_MakeCurrent(main) failed in createSharedContext: "
                    << SDL_GetError() << LL_ENDL;
     }
 
-    if (!pContext)
+    // A version request derived from the live main context, clamped to the
+    // range the viewer supports. WGL/EGL need this explicitly (mirroring
+    // LLWindowWin32::createSharedContext); GLX/CGL inherit it from the share
+    // context, hence the guard against an unused-variable warning there.
+#if LL_WINDOWS || LL_WAYLAND
+    const F32 gl_ver = llclamp(gGLManager.mGLVersion, 3.0f, 4.6f);
+    const S32 ver_major = (S32)gl_ver;
+    const S32 ver_minor = (S32)ll_round((gl_ver - ver_major) * 10.f);
+#endif
+
+    auto* shared = new LLSDLSharedContext();
+    bool ok = false;
+
+#if LL_WINDOWS
+    HDC   dc    = wglGetCurrentDC();
+    HGLRC share = wglGetCurrentContext();
+    if (dc && share && wglCreateContextAttribsARB)
     {
-        LL_WARNS() << "Creating shared OpenGL context failed: " << SDL_GetError() << LL_ENDL;
-        SDL_DestroyWindow(osr_window);
+        S32 attribs[] =
+        {
+            WGL_CONTEXT_MAJOR_VERSION_ARB, ver_major,
+            WGL_CONTEXT_MINOR_VERSION_ARB, ver_minor,
+            WGL_CONTEXT_PROFILE_MASK_ARB,  LLRender::sGLCoreProfile ? WGL_CONTEXT_CORE_PROFILE_BIT_ARB : WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+            WGL_CONTEXT_FLAGS_ARB, gDebugGL ? WGL_CONTEXT_DEBUG_BIT_ARB : 0,
+            0
+        };
+        HGLRC rc = nullptr;
+        for (;;)
+        {
+            rc = wglCreateContextAttribsARB(dc, share, attribs);
+            if (rc) break;
+            if (attribs[3] > 0)      { attribs[3]--; }                   // step minor down
+            else if (attribs[1] > 3) { attribs[1]--; attribs[3] = 3; }   // step major down
+            else                     { break; }                         // gave up at 3.0
+        }
+        if (rc)
+        {
+            shared->rc = rc;
+            shared->dc = dc;
+            ok = true;
+        }
+        else
+        {
+            LL_WARNS() << "wglCreateContextAttribsARB (shared) failed" << LL_ENDL;
+        }
+    }
+#elif LL_DARWIN
+    CGLContextObj share = CGLGetCurrentContext();
+    if (share)
+    {
+        CGLPixelFormatObj pf = CGLGetPixelFormat(share);
+        CGLContextObj ctx = nullptr;
+        CGLError err = CGLCreateContext(pf, share, &ctx);
+        if (err == kCGLNoError && ctx)
+        {
+            shared->ctx = ctx;
+            ok = true;
+        }
+        else
+        {
+            LL_WARNS() << "CGLCreateContext (shared) failed: " << CGLErrorString(err) << LL_ENDL;
+        }
+    }
+#else // LL_LINUX
+#if LL_X11
+    if (mServerProtocol == X11)
+    {
+        // GLX: bind the shared context to a 1x1 offscreen GLXPbuffer (no window
+        // manager interaction, destroyable from the worker thread). Each worker
+        // needs its own drawable — reusing the main window drawable would
+        // BadAccess (it's already current on the main thread).
+        typedef Display*     (*fn_getdpy)(void);
+        typedef GLXContext   (*fn_getctx)(void);
+        typedef GLXFBConfig* (*fn_choose)(Display*, int, const int*, int*);
+        typedef GLXContext   (*fn_newctx)(Display*, GLXFBConfig, int, GLXContext, Bool);
+        typedef GLXPbuffer   (*fn_pbuffer)(Display*, GLXFBConfig, const int*);
+
+        auto glx_getdpy  = (fn_getdpy)SDL_GL_GetProcAddress("glXGetCurrentDisplay");
+        auto glx_getctx  = (fn_getctx)SDL_GL_GetProcAddress("glXGetCurrentContext");
+        auto glx_choose  = (fn_choose)SDL_GL_GetProcAddress("glXChooseFBConfig");
+        auto glx_newctx  = (fn_newctx)SDL_GL_GetProcAddress("glXCreateNewContext");
+        auto glx_pbuffer = (fn_pbuffer)SDL_GL_GetProcAddress("glXCreatePbuffer");
+
+        if (glx_getdpy && glx_getctx && glx_choose && glx_newctx && glx_pbuffer)
+        {
+            Display*   dpy   = glx_getdpy();
+            GLXContext share = glx_getctx();
+            int screen = (sX11Data.xscreen >= 0) ? sX11Data.xscreen : (dpy ? DefaultScreen(dpy) : 0);
+            const int cfg_attribs[] =
+            {
+                GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
+                GLX_RENDER_TYPE,   GLX_RGBA_BIT,
+                GLX_RED_SIZE, 8, GLX_GREEN_SIZE, 8, GLX_BLUE_SIZE, 8, GLX_ALPHA_SIZE, 8,
+                None
+            };
+            int n = 0;
+            GLXFBConfig* fbc = (dpy ? glx_choose(dpy, screen, cfg_attribs, &n) : nullptr);
+            if (fbc && n > 0)
+            {
+                const int pb_attribs[] = { GLX_PBUFFER_WIDTH, 1, GLX_PBUFFER_HEIGHT, 1, None };
+                GLXPbuffer pbuf = glx_pbuffer(dpy, fbc[0], pb_attribs);
+                GLXContext ctx  = glx_newctx(dpy, fbc[0], GLX_RGBA_TYPE, share, True);
+                XFree(fbc);
+                if (pbuf && ctx)
+                {
+                    shared->glx_dpy  = dpy;
+                    shared->glx_pbuf = pbuf;
+                    shared->glx_ctx  = ctx;
+                    ok = true;
+                }
+                else
+                {
+                    LL_WARNS() << "GLX shared pbuffer/context creation failed" << LL_ENDL;
+                    LLSDLSharedContext tmp; tmp.glx_dpy = dpy; tmp.glx_ctx = ctx; tmp.glx_pbuf = pbuf;
+                    tearDownNativeSharedContext(&tmp);
+                }
+            }
+            else
+            {
+                LL_WARNS() << "glXChooseFBConfig found no pbuffer-capable config" << LL_ENDL;
+            }
+        }
+        else
+        {
+            LL_WARNS() << "Could not resolve GLX entry points for shared context" << LL_ENDL;
+        }
+    }
+#endif // LL_X11
+#if LL_WAYLAND
+    if (mServerProtocol == Wayland)
+    {
+        // Wayland / EGL: a surfaceless context (EGL_NO_SURFACE) avoids needing a
+        // per-worker drawable. Requires EGL_KHR_surfaceless_context (Mesa has
+        // it). SDL exposes the display/config it created the main context with.
+        typedef void* (*fn_getctx)(void);
+        typedef void* (*fn_createctx)(void*, void*, void*, const int*);
+        typedef unsigned int (*fn_bindapi)(unsigned int);
+
+        auto egl_getctx    = (fn_getctx)SDL_EGL_GetProcAddress("eglGetCurrentContext");
+        auto egl_createctx = (fn_createctx)SDL_EGL_GetProcAddress("eglCreateContext");
+        auto egl_bindapi   = (fn_bindapi)SDL_EGL_GetProcAddress("eglBindAPI");
+
+        void* dpy   = (void*)SDL_EGL_GetCurrentDisplay();
+        void* cfg   = (void*)SDL_EGL_GetCurrentConfig();
+        void* share = egl_getctx ? egl_getctx() : nullptr;
+
+        if (dpy && egl_createctx && share)
+        {
+            if (egl_bindapi) egl_bindapi(EGL_OPENGL_API);
+            // Must request the version explicitly — an empty attrib list defaults
+            // to GL 1.0, which can't drive the modern texture/VBO uploads the
+            // worker shares with the main context. (EGL 1.5 tokens.)
+            const int ctx_attribs[] =
+            {
+                EGL_CONTEXT_MAJOR_VERSION, ver_major,
+                EGL_CONTEXT_MINOR_VERSION, ver_minor,
+                EGL_NONE
+            };
+            void* ctx = egl_createctx(dpy, cfg, share, ctx_attribs);
+            if (ctx && ctx != EGL_NO_CONTEXT)
+            {
+                shared->egl_dpy = dpy;
+                shared->egl_ctx = ctx;
+                ok = true;
+            }
+            else
+            {
+                LL_WARNS() << "eglCreateContext (shared) failed" << LL_ENDL;
+            }
+        }
+        else
+        {
+            LL_WARNS() << "Could not resolve EGL state/entry points for shared context" << LL_ENDL;
+        }
+    }
+#endif // LL_WAYLAND
+#endif // LL_LINUX
+
+    if (!ok)
+    {
+        delete shared;
         return nullptr;
     }
 
     {
-        LLMutexLock osr_lock(&mOSRMutex);
-        mOSRContexts.emplace(pContext, osr_window);
+        LLMutexLock lk(&mSharedCtxMutex);
+        mSharedContexts.insert(shared);
     }
-
-    LL_DEBUGS() << "Creating shared OpenGL context successful!" << LL_ENDL;
-    return (void*)pContext;
+    LL_DEBUGS() << "Created native shared GL context." << LL_ENDL;
+    return shared;
 }
 
 void LLWindowSDL::makeContextCurrent(void* contextPtr)
 {
-    LLMutexLock osr_lock(&mOSRMutex);
-    auto it = mOSRContexts.find((SDL_GLContext)contextPtr);
-    if(it != mOSRContexts.end())
+    if (!contextPtr) return;
+    auto* s = (LLSDLSharedContext*)contextPtr;
+#if LL_WINDOWS
+    if (!wglMakeCurrent(s->dc, s->rc))
     {
-        if (!SDL_GL_MakeCurrent((SDL_Window*)it->second, (SDL_GLContext)it->first))
+        LL_WARNS("Window") << "wglMakeCurrent(shared) failed: " << GetLastError() << LL_ENDL;
+    }
+#elif LL_DARWIN
+    CGLSetCurrentContext(s->ctx);
+#else // LL_LINUX
+#if LL_X11
+    if (s->glx_ctx)
+    {
+        typedef Bool (*fn_makecur)(Display*, GLXDrawable, GLXContext);
+        auto glx_makecur = (fn_makecur)SDL_GL_GetProcAddress("glXMakeCurrent");
+        if (glx_makecur && !glx_makecur(s->glx_dpy, s->glx_pbuf, s->glx_ctx))
         {
-            LL_WARNS() << "SDL_GL_MakeCurrent(OSR) failed: " << SDL_GetError() << LL_ENDL;
+            LL_WARNS("Window") << "glXMakeCurrent(shared) failed" << LL_ENDL;
         }
     }
+#endif
+#if LL_WAYLAND
+    if (s->egl_ctx)
+    {
+        // eglBindAPI is per-thread, so re-assert OpenGL on the worker before
+        // binding the context surfaceless.
+        typedef unsigned int (*fn_bindapi)(unsigned int);
+        typedef unsigned int (*fn_makecur)(void*, void*, void*, void*);
+        auto egl_bindapi = (fn_bindapi)SDL_EGL_GetProcAddress("eglBindAPI");
+        auto egl_makecur = (fn_makecur)SDL_EGL_GetProcAddress("eglMakeCurrent");
+        if (egl_bindapi) egl_bindapi(EGL_OPENGL_API);
+        if (egl_makecur && !egl_makecur(s->egl_dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, s->egl_ctx))
+        {
+            LL_WARNS("Window") << "eglMakeCurrent(shared, surfaceless) failed" << LL_ENDL;
+        }
+    }
+#endif
+#endif // LL_LINUX
     LL_PROFILER_GPU_CONTEXT;
 }
 
 void LLWindowSDL::destroySharedContext(void* contextPtr)
 {
-    LLMutexLock osr_lock(&mOSRMutex);
-    auto it = mOSRContexts.find((SDL_GLContext)contextPtr);
-    if(it != mOSRContexts.end())
+    if (!contextPtr) return;
+    auto* s = (LLSDLSharedContext*)contextPtr;
+    tearDownNativeSharedContext(s);
     {
-        SDL_GL_DestroyContext((SDL_GLContext)it->first);
-        mDeadOSRWindows.push_back((SDL_Window*)it->second);
+        LLMutexLock lk(&mSharedCtxMutex);
+        mSharedContexts.erase(s);
     }
+    delete s;
 }
 
 void LLWindowSDL::toggleVSync(bool enable_vsync)
@@ -708,29 +972,24 @@ void LLWindowSDL::destroyContext()
     LL_INFOS() << "destroyContext begins" << LL_ENDL;
 
     {
-        LLMutexLock osr_lock(&mOSRMutex);
-
-        // Tear down any still-live OSR contexts. Worker threads are expected to
-        // release them via destroySharedContext() first; if we still have entries
-        // here at shutdown it means a thread didn't, and we'd leak both the GL
-        // context and its hidden window.
-        if (!mOSRContexts.empty())
+        // Reclaim any shared GL contexts a worker thread failed to release.
+        // Normal shutdown joins the GL worker threads before destroyContext, so
+        // this is defensive — a leftover here means a worker didn't call
+        // destroySharedContext(). The native contexts can be torn down from the
+        // main thread (unlike the old carrier-window path, no deferral needed).
+        LLMutexLock lk(&mSharedCtxMutex);
+        if (!mSharedContexts.empty())
         {
-            LL_WARNS() << "destroyContext: " << mOSRContexts.size()
+            LL_WARNS() << "destroyContext: " << mSharedContexts.size()
                        << " shared GL context(s) still alive at shutdown — releasing." << LL_ENDL;
-            for (auto& kv : mOSRContexts)
+            for (void* handle : mSharedContexts)
             {
-                SDL_GL_DestroyContext(kv.first);
-                mDeadOSRWindows.push_back(kv.second);
+                auto* s = (LLSDLSharedContext*)handle;
+                tearDownNativeSharedContext(s);
+                delete s;
             }
-            mOSRContexts.clear();
+            mSharedContexts.clear();
         }
-
-        for(SDL_Window* pWindow : mDeadOSRWindows)
-        {
-            SDL_DestroyWindow(pWindow);
-        }
-        mDeadOSRWindows.clear();
     }
 
 #if LL_WINDOWS
@@ -781,20 +1040,6 @@ void LLWindowSDL::destroyContext()
     else
     {
         LL_INFOS() << "SDL Window already destroyed" << LL_ENDL;
-    }
-
-    // Final OSR drain in case a worker thread queued more dead windows
-    // between the earlier drain and now. Normal shutdown ordering joins
-    // worker threads before destroyContext runs, so this is defensive —
-    // it pairs with the inline note in destroySharedContext that the
-    // drain is single-owner from the main thread.
-    {
-        LLMutexLock osr_lock(&mOSRMutex);
-        for (SDL_Window* pWindow : mDeadOSRWindows)
-        {
-            SDL_DestroyWindow(pWindow);
-        }
-        mDeadOSRWindows.clear();
     }
 
     // Reset per-window state so switchContext (which calls destroyContext +
@@ -1726,14 +1971,9 @@ U32 LLWindowSDL::SDLCheckGrabbyKeys(U32 keysym, bool gain)
 // virtual
 void LLWindowSDL::processMiscNativeEvents()
 {
-    {
-        LLMutexLock osr_lock(&mOSRMutex);
-        for(SDL_Window* pWindow : mDeadOSRWindows)
-        {
-            SDL_DestroyWindow(pWindow);
-        }
-        mDeadOSRWindows.clear();
-    }
+    // Native shared GL contexts (createSharedContext) are torn down directly by
+    // the worker thread in destroySharedContext() — there is no deferred
+    // main-thread window-destruction queue to drain here anymore.
 }
 
 void LLWindowSDL::gatherInput()

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -794,7 +794,21 @@ void* LLWindowSDL::createSharedContext()
                 const int pb_attribs[] = { GLX_PBUFFER_WIDTH, 1, GLX_PBUFFER_HEIGHT, 1, None };
                 GLXPbuffer pbuf = glx_pbuffer(dpy, fbc[0], pb_attribs);
                 GLXContext ctx  = glx_newctx(dpy, fbc[0], GLX_RGBA_TYPE, share, True);
-                XFree(fbc);
+                // glXChooseFBConfig returns an Xlib-allocated array that must be
+                // released with XFree. The SDL backend doesn't link libX11 (GLX
+                // is reached through SDL_GL_GetProcAddress), so resolve XFree from
+                // the already-resident libX11 at runtime via SDL's loader instead
+                // of taking an X11 link dependency. On the X11 server path libX11
+                // is always loaded; if XFree can't be found, skip the free (a
+                // tiny, bounded, once-per-worker-context leak) rather than crash.
+                if (SDL_SharedObject* x11lib = SDL_LoadObject("libX11.so.6"))
+                {
+                    if (SDL_FunctionPointer x_free = SDL_LoadFunction(x11lib, "XFree"))
+                    {
+                        ((int (*)(void*))x_free)(fbc);
+                    }
+                    SDL_UnloadObject(x11lib);
+                }
                 if (pbuf && ctx)
                 {
                     shared->glx_dpy  = dpy;

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -40,6 +40,9 @@
 #include "llpreeditor.h"
 #include "llsdl.h"
 
+#include "SDL3_ttf/SDL_ttf.h"     // LLSplashScreenSDL status text
+#include "SDL3_image/SDL_image.h" // LLSplashScreenSDL branded icon (PNG)
+
 #if LL_LINUX
 extern "C" {
 # include "fontconfig/fontconfig.h"
@@ -3441,9 +3444,29 @@ void LLWindowSDL::showCursorFromMouseMove()
 }
 
 //
-// LLSplashScreenSDL - I don't think we'll bother to implement this; it's
-// fairly obsolete at this point.
+// LLSplashScreenSDL — a small borderless status window shown while the viewer
+// loads, mirroring LLSplashScreenWin32 (the app name plus an updatable status
+// line). Drawn with SDL_Renderer; text rendered with SDL_ttf from one of the
+// viewer's bundled fonts.
 //
+namespace
+{
+    constexpr int   SPLASH_W        = 480;
+    constexpr int   SPLASH_H        = 120;
+    constexpr float SPLASH_FONT_PT  = 18.0f;
+    // Inter (variable WOFF2) — FreeType decompresses WOFF2 via brotli, which the
+    // viewer's freetype build (shared with SDL3_ttf) enables.
+    const char*     SPLASH_FONT     = "InterVariable.woff2";
+    // Branded icon, vertically centered in a square box on the left.
+    constexpr int   SPLASH_ICON     = 80;
+    constexpr int   SPLASH_ICON_X   = 20;
+    constexpr int   SPLASH_ICON_Y   = (SPLASH_H - SPLASH_ICON) / 2;
+    const char*     SPLASH_ICON_PNG = "alchemy_logo.png";
+    // Status text is centered in the area to the right of the icon.
+    constexpr int   SPLASH_TEXT_X0  = SPLASH_ICON_X + SPLASH_ICON + 16;
+    constexpr int   SPLASH_TEXT_X1  = SPLASH_W - 16;
+}
+
 LLSplashScreenSDL::LLSplashScreenSDL()
 {
 }
@@ -3454,14 +3477,192 @@ LLSplashScreenSDL::~LLSplashScreenSDL()
 
 void LLSplashScreenSDL::showImpl()
 {
+    // The splash is shown before createWindow()/init_sdl(), so the video
+    // subsystem may not be up yet. SDL_InitSubSystem is reference-counted, so
+    // initialising it here is safe; hideImpl() releases exactly this reference,
+    // leaving the count the main window's own init_sdl() established.
+    if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
+    {
+        LL_WARNS() << "Splash: SDL_InitSubSystem(VIDEO) failed: " << SDL_GetError() << LL_ENDL;
+        return;
+    }
+    mInitedVideo = true;
+
+    if (TTF_Init())
+    {
+        mInitedTTF = true;
+    }
+    else
+    {
+        LL_WARNS() << "Splash: TTF_Init failed: " << SDL_GetError() << LL_ENDL;
+    }
+
+    SDL_PropertiesID props = SDL_CreateProperties();
+    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, "Alchemy");
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, SDL_WINDOWPOS_CENTERED);
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, SDL_WINDOWPOS_CENTERED);
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, SPLASH_W);
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, SPLASH_H);
+    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_BORDERLESS_BOOLEAN, true);
+    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN, true);
+    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_UTILITY_BOOLEAN, true);
+    mWindow = SDL_CreateWindowWithProperties(props);
+    SDL_DestroyProperties(props);
+
+    if (!mWindow)
+    {
+        LL_WARNS() << "Splash: window creation failed: " << SDL_GetError() << LL_ENDL;
+        return;
+    }
+
+    // Use a software renderer that draws into the window's surface rather than
+    // an accelerated one. SDL's accelerated renderer would create its own
+    // GL/D3D device on the splash window, which can collide with the main
+    // window's OpenGL context initialisation that follows — keep the splash
+    // entirely off the GPU.
+    SDL_Surface* winsurf = SDL_GetWindowSurface(mWindow);
+    if (winsurf)
+    {
+        mRenderer = SDL_CreateSoftwareRenderer(winsurf);
+    }
+    if (!mRenderer)
+    {
+        LL_WARNS() << "Splash: software renderer creation failed: " << SDL_GetError() << LL_ENDL;
+    }
+
+    if (mInitedTTF)
+    {
+        const std::string font_path = gDirUtilp->add(gDirUtilp->getAppRODataDir(), "fonts", SPLASH_FONT);
+        mFont = TTF_OpenFont(font_path.c_str(), SPLASH_FONT_PT);
+        if (!mFont)
+        {
+            LL_WARNS() << "Splash: TTF_OpenFont(" << font_path << ") failed: " << SDL_GetError() << LL_ENDL;
+        }
+    }
+
+    // Branded app icon (PNG), staged into app_settings by CMake.
+    if (mRenderer)
+    {
+        const std::string icon_path = gDirUtilp->getExpandedFilename(LL_PATH_APP_SETTINGS, SPLASH_ICON_PNG);
+        SDL_Surface* icon_surf = IMG_Load(icon_path.c_str());
+        if (icon_surf)
+        {
+            mIcon = SDL_CreateTextureFromSurface(mRenderer, icon_surf);
+            // Smooth the downscale from the source (256px) to the splash box.
+            if (mIcon)
+            {
+                SDL_SetTextureScaleMode(mIcon, SDL_SCALEMODE_LINEAR);
+            }
+            SDL_DestroySurface(icon_surf);
+        }
+        else
+        {
+            LL_WARNS() << "Splash: IMG_Load(" << icon_path << ") failed: " << SDL_GetError() << LL_ENDL;
+        }
+    }
+
+    render();
 }
 
 void LLSplashScreenSDL::updateImpl(const std::string& mesg)
 {
+    mMessage = mesg;
+    render();
+}
+
+void LLSplashScreenSDL::render()
+{
+    if (!mRenderer)
+    {
+        return;
+    }
+
+    SDL_SetRenderDrawColor(mRenderer, 28, 28, 34, 255);
+    SDL_RenderClear(mRenderer);
+
+    // Thin accent border around the edge.
+    SDL_SetRenderDrawColor(mRenderer, 90, 110, 160, 255);
+    SDL_FRect border = { 0.5f, 0.5f, (float)SPLASH_W - 1.f, (float)SPLASH_H - 1.f };
+    SDL_RenderRect(mRenderer, &border);
+
+    // Branded icon, vertically centered on the left.
+    if (mIcon)
+    {
+        SDL_FRect dst = { (float)SPLASH_ICON_X, (float)SPLASH_ICON_Y, (float)SPLASH_ICON, (float)SPLASH_ICON };
+        SDL_RenderTexture(mRenderer, mIcon, nullptr, &dst);
+    }
+
+    if (mFont)
+    {
+        TTF_Font* font = (TTF_Font*)mFont;
+        const SDL_Color fg = { 235, 235, 240, 255 };
+        const std::string& text = mMessage.empty() ? std::string("Loading Alchemy...") : mMessage;
+        SDL_Surface* surf = TTF_RenderText_Blended(font, text.c_str(), text.length(), fg);
+        if (surf)
+        {
+            SDL_Texture* tex = SDL_CreateTextureFromSurface(mRenderer, surf);
+            if (tex)
+            {
+                // Center the text in the area to the right of the icon.
+                const int region = SPLASH_TEXT_X1 - SPLASH_TEXT_X0;
+                SDL_FRect dst = {
+                    (float)(SPLASH_TEXT_X0 + (region - surf->w) / 2),
+                    (float)((SPLASH_H - surf->h) / 2),
+                    (float)surf->w,
+                    (float)surf->h
+                };
+                SDL_RenderTexture(mRenderer, tex, nullptr, &dst);
+                SDL_DestroyTexture(tex);
+            }
+            SDL_DestroySurface(surf);
+        }
+    }
+
+    // Flush the queued render commands into the window surface, then blit that
+    // surface to the screen (the software renderer targets the surface, not the
+    // window directly, so SDL_RenderPresent alone wouldn't show anything).
+    SDL_RenderPresent(mRenderer);
+    SDL_UpdateWindowSurface(mWindow);
+
+    // No SDL event loop is running yet (the splash precedes the main window and
+    // SDL_AppIterate), so pump once here to let the window actually composite.
+    SDL_PumpEvents();
 }
 
 void LLSplashScreenSDL::hideImpl()
 {
+    if (mIcon)
+    {
+        SDL_DestroyTexture(mIcon);
+        mIcon = nullptr;
+    }
+    if (mFont)
+    {
+        TTF_CloseFont((TTF_Font*)mFont);
+        mFont = nullptr;
+    }
+    if (mRenderer)
+    {
+        SDL_DestroyRenderer(mRenderer);
+        mRenderer = nullptr;
+    }
+    if (mWindow)
+    {
+        SDL_DestroyWindow(mWindow);
+        mWindow = nullptr;
+    }
+    if (mInitedTTF)
+    {
+        TTF_Quit();
+        mInitedTTF = false;
+    }
+    if (mInitedVideo)
+    {
+        // Release the reference showImpl() took. By now createWindow()'s
+        // init_sdl() has taken its own, so VIDEO stays up for the main window.
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+        mInitedVideo = false;
+    }
 }
 
 S32 OSMessageBoxSDL(const std::string& text, const std::string& caption, U32 type)

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -1501,6 +1501,13 @@ F32 LLWindowSDL::getNativeAspectRatio()
     // of the monitor...this seems to work to a close approximation for most CRTs/LCDs
     S32 num_resolutions;
     LLWindowResolution* resolutions = getSupportedResolutions(num_resolutions);
+    if (!resolutions || num_resolutions <= 0)
+    {
+        // No usable display modes (e.g. Wayland exposes none, or nothing met the
+        // 800x600 floor). Fall back to the 4:3 assumption rather than indexing
+        // resolutions[-1] and dividing by a garbage height.
+        return 1024.f / 768.f;
+    }
 
     return ((F32)resolutions[num_resolutions - 1].mWidth / (F32)resolutions[num_resolutions - 1].mHeight);
 }
@@ -1608,6 +1615,8 @@ void LLWindowSDL::flashIcon(F32 seconds)
     mFlashTimer.reset();
     mFlashTimer.setTimerExpirySec(remaining_time);
 
+    if (!mWindow)
+        return;
     SDL_FlashWindow(mWindow, SDL_FLASH_UNTIL_FOCUSED);
     mFlashing = true;
 }
@@ -1617,7 +1626,8 @@ void LLWindowSDL::maybeStopFlashIcon()
     if (mFlashing && mFlashTimer.hasExpired())
     {
         mFlashing = false;
-        SDL_FlashWindow( mWindow, SDL_FLASH_CANCEL );
+        if (mWindow)
+            SDL_FlashWindow( mWindow, SDL_FLASH_CANCEL );
     }
 }
 
@@ -1999,7 +2009,8 @@ void LLWindowSDL::gatherInput()
     // expired.
     if (mFlashing && mFlashTimer.hasExpired())
     {
-        SDL_FlashWindow(mWindow, SDL_FLASH_CANCEL);
+        if (mWindow)
+            SDL_FlashWindow(mWindow, SDL_FLASH_CANCEL);
         mFlashing = false;
     }
 }
@@ -2373,8 +2384,15 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // We do NOT filter on MASK_ALT alone — Right-Alt (AltGr) on
             // European keyboards composes characters like Å/Ø/€ and those
             // legitimately arrive via TEXT_INPUT.
-            const Uint16 modstate = SDL_GetModState();
-            if (modstate & SDL_KMOD_CTRL)
+            // Use the modifier state captured WITH the keystroke (mKeyModifiers,
+            // set from event.key.mod on the KEY_DOWN that produced this text),
+            // not the live SDL_GetModState(): gatherInput drains the whole event
+            // batch at once, so a fast Ctrl+key whose Ctrl-release lands in the
+            // same pump would read CTRL as already up here and fail to drop the
+            // accelerator's literal character (Ctrl-A then "a" overwriting the
+            // selection). mKeyModifiers reflects the producing keystroke, and an
+            // IME commit refreshes it via its own non-Ctrl key-downs.
+            if (mKeyModifiers & SDL_KMOD_CTRL)
             {
                 break;
             }
@@ -2501,8 +2519,12 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // with a degenerate 0x0 rectangle.
             const F32 raw_density = SDL_GetWindowPixelDensity(mWindow);
             const F32 pixel_density = raw_density > 0.f ? raw_density : 1.f;
-            S32 width = (S32)(llmax(event.window.data1, (S32)mMinWindowWidth) * pixel_density);
-            S32 height = (S32)(llmax(event.window.data2, (S32)mMinWindowHeight) * pixel_density);
+            // mMinWindowWidth/Height are 0 until setMinSize runs, so llmax can't
+            // keep these positive this early. Floor to 1px so a 0-dimension
+            // resize (some WMs emit one mid-drag / on un-maximize) never reaches
+            // handleResize as a degenerate 0x0 viewport / divide-by-zero aspect.
+            S32 width = llmax(1, (S32)(llmax(event.window.data1, (S32)mMinWindowWidth) * pixel_density));
+            S32 height = llmax(1, (S32)(llmax(event.window.data2, (S32)mMinWindowHeight) * pixel_density));
 
             mCallbacks->handleResize(this, width, height);
             break;
@@ -2516,8 +2538,11 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
             // so the clamp has to use the PIXEL-unit minimum shadow — the
             // screen-coord mMinWindowWidth/Height would under-clamp on HiDPI.
             LL_INFOS() << "Handling a pixel-size event: " << event.window.data1 << "x" << event.window.data2 << LL_ENDL;
-            S32 width  = llmax(event.window.data1, (S32)mMinWindowWidthPx);
-            S32 height = llmax(event.window.data2, (S32)mMinWindowHeightPx);
+            // Floor to 1px: mMinWindowWidthPx/HeightPx are 0 until setMinSize
+            // runs, so a 0-dimension pixel-size event would otherwise pass
+            // through as a degenerate 0x0 resize.
+            S32 width  = llmax(1, llmax(event.window.data1, (S32)mMinWindowWidthPx));
+            S32 height = llmax(1, llmax(event.window.data2, (S32)mMinWindowHeightPx));
             mCallbacks->handleResize(this, width, height);
             break;
         }
@@ -2776,7 +2801,11 @@ SDL_AppResult LLWindowSDL::handleEvent(const SDL_Event& event)
 // static
 SDL_AppResult LLWindowSDL::handleEvents(const SDL_Event& event)
 {
-    if(!gWindowImplementation) return SDL_APP_CONTINUE;
+    // Drop events once the window is gone. During teardown destroyContext()
+    // nulls mWindow before ~LLWindowSDL clears gWindowImplementation, and the
+    // per-event handlers below deref mWindow (SDL_GetWindowSizeInPixels, relative
+    // mouse mode, DPI) without their own guards.
+    if (!gWindowImplementation || !gWindowImplementation->mWindow) return SDL_APP_CONTINUE;
 
     return gWindowImplementation->handleEvent(event);
 }
@@ -3528,6 +3557,12 @@ void LLSplashScreenSDL::showImpl()
     if (!mRenderer)
     {
         LL_WARNS() << "Splash: software renderer creation failed: " << SDL_GetError() << LL_ENDL;
+        // Don't leave a blank borderless always-on-top window up for the whole
+        // load. Tear the partial splash window down now; hideImpl() still
+        // balances the TTF/VIDEO subsystem refcounts taken above.
+        SDL_DestroyWindow(mWindow);
+        mWindow = nullptr;
+        return;
     }
 
     if (mInitedTTF)

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -272,6 +272,13 @@ protected:
     // density might have changed under us.
     void refreshMinSizePixelShadow();
 
+    // Re-cache the window pixel density + pixel height that the per-event input
+    // handlers and convertCoords read, so they don't each hit
+    // SDL_GetWindowPixelDensity / SDL_GetWindowSizeInPixels (-> GetClientRect, a
+    // USER32 syscall) on every mouse event. Run wherever the window's pixel size
+    // or density can change (resize / DPI / monitor).
+    void refreshPixelMetrics();
+
     //
     // Platform specific variables
     //
@@ -318,6 +325,12 @@ private:
     // re-clamps against this pixel-unit copy to make the dimensions match.
     U32 mMinWindowWidthPx = 0;
     U32 mMinWindowHeightPx = 0;
+
+    // Cached pixel metrics; see refreshPixelMetrics(). Density is pre-clamped to
+    // > 0. Height starts at 0 — convertCoords falls back to a live query until
+    // the first refresh (end of createContext).
+    F32 mCachedPixelDensity = 1.f;
+    S32 mCachedWindowHeightPx = 0;
 
     F32 mMouseDeltaAccumX = 0.f;
     F32 mMouseDeltaAccumY = 0.f;

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -33,6 +33,8 @@
 #include "lltimer.h"
 #include "llmutex.h"
 
+#include <set>
+
 #include "SDL3/SDL.h"
 #include "SDL3/SDL_endian.h"
 
@@ -395,29 +397,26 @@ private:
     LLCoordWindow mDeferredCursorWarp;
     bool mHasDeferredCursorWarp = false;
 
-    // Off-screen rendering (OSR) shared GL contexts.
+    // Shared GL contexts for worker threads (texture upload, VBO streaming).
     //
-    // Worker threads (texture loader, etc.) ask for a shared GL context via
-    // createSharedContext() and bind it via makeContextCurrent() so they can
-    // upload textures without interrupting the main render thread. SDL3's
-    // OSR pattern is one hidden 1x1 SDL_Window per shared GL context.
+    // Worker threads ask for a shared GL context via createSharedContext() (on
+    // the main thread), bind it via makeContextCurrent() and release it with
+    // destroySharedContext() (both on the worker thread) so they can stream GL
+    // objects without interrupting the main render thread.
     //
-    // Threading contract:
-    //   * mOSRContexts is touched ONLY under mOSRMutex.
-    //   * Worker threads MAY call createSharedContext / destroySharedContext /
-    //     makeContextCurrent — those acquire the mutex internally.
-    //   * SDL_DestroyWindow is main-thread-only on at least X11 (the X11
-    //     backend grabs the global SDL video lock and assumes single-threaded
-    //     entry), so destroySharedContext does NOT destroy the carrier window
-    //     directly; it queues it onto mDeadOSRWindows for the main thread to
-    //     reap in processMiscNativeEvents() / destroyContext().
-    //   * destroyContext() also walks any contexts still in mOSRContexts at
-    //     shutdown — those represent worker threads that didn't release
-    //     their context — and queues their windows for destruction on the
-    //     same path.
-    LLMutex mOSRMutex;
-    std::unordered_map<SDL_GLContext, SDL_Window*> mOSRContexts;
-    std::list<SDL_Window*> mDeadOSRWindows;
+    // Rather than SDL3's "one hidden carrier SDL_Window per context" pattern
+    // (which forces a main-thread-only deferred-window-destruction dance), we
+    // create the contexts with the platform-native GL API behind SDL:
+    //   * Windows  — WGL sibling context on the main window's HDC
+    //   * macOS    — CGL context sharing the current CGLContextObj (drawable-less)
+    //   * X11      — GLX context bound to a 1x1 GLXPbuffer (offscreen, no WM)
+    //   * Wayland  — EGL context made current surfaceless (EGL_NO_SURFACE)
+    // Each returns an opaque heap handle (LLSDLSharedContext, defined in the
+    // .cpp). mSharedContexts tracks the live handles ONLY so destroyContext can
+    // warn about and reclaim any a worker failed to release; it is touched only
+    // under mSharedCtxMutex.
+    LLMutex mSharedCtxMutex;
+    std::set<void*> mSharedContexts;
 
     // Files accumulated between SDL_EVENT_DROP_BEGIN and SDL_EVENT_DROP_COMPLETE.
     // Each SDL_EVENT_DROP_FILE only carries one path, so we batch them and

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -487,6 +487,19 @@ public:
     void showImpl() override;
     void updateImpl(const std::string& mesg) override;
     void hideImpl() override;
+
+private:
+    // Redraw the splash (background + current status text) and pump events so
+    // it paints while the main thread is busy loading.
+    void render();
+
+    SDL_Window*   mWindow = nullptr;
+    SDL_Renderer* mRenderer = nullptr;
+    void*         mFont = nullptr;   // TTF_Font* (kept opaque to spare the header SDL_ttf)
+    SDL_Texture*  mIcon = nullptr;   // branded app icon, left side
+    std::string   mMessage;
+    bool          mInitedVideo = false;
+    bool          mInitedTTF = false;
 };
 
 S32 OSMessageBoxSDL(const std::string& text, const std::string& caption, U32 type);

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -36,6 +36,10 @@
 #include "SDL3/SDL.h"
 #include "SDL3/SDL_endian.h"
 
+#if LL_WINDOWS
+#include "llwin32headers.h" // HWND / WNDPROC for the WM_COPYDATA subclass
+#endif
+
 #ifdef LL_WAYLAND
 #include <wayland-client-protocol.h>
 #endif
@@ -213,6 +217,21 @@ public:
     static void setUseMultGL(bool use_mult_gl);
 
     static bool sUseMultGL;
+#endif
+
+#if LL_WINDOWS
+    // DirectInput8 access for llviewerjoystick / SpaceNavigator — same
+    // contract as LLWindowWin32 (DI8 needs only the module handle, not the
+    // window, so the SDL backend can provide it too).
+    void* getDirectInput8() override;
+    bool getInputDevices(U32 device_type_filter,
+                         std::function<bool(std::string&, LLSD&, void*)> osx_callback,
+                         void* di8_devices_callback,
+                         void* userdata) override;
+
+    // Forwards WM_COPYDATA payloads (SLURL hand-off from a second viewer
+    // instance) from the subclassed WndProc to the window callbacks.
+    void handleDataCopy(S32 data_type, void* data);
 #endif
 
 protected:
@@ -424,6 +443,19 @@ private:
 
     enum EServerProtocol{ X11, Wayland, Unknown };
     EServerProtocol mServerProtocol = Unknown;
+
+#if LL_WINDOWS
+    // Install/remove a WndProc subclass on the SDL window's HWND so we can
+    // service WM_COPYDATA (SLURL hand-off from a second instance) — SDL3's
+    // message hook never sees cross-process SendMessage. Paired around the
+    // SDL window lifetime in createContext/destroyContext.
+    void installWin32Subclass();
+    void removeWin32Subclass();
+    static LRESULT CALLBACK win32WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam);
+
+    HWND mWin32Hwnd = nullptr;
+    WNDPROC mPrevWndProc = nullptr;
+#endif
 public:
 #if LL_X11
     // X11

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2907,20 +2907,21 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
 
             S16 incoming_z_delta = HIWORD(w_param);
             z_delta += incoming_z_delta;
-            // cout << "z_delta " << z_delta << endl;
 
             // current mouse wheels report changes in increments of zDelta (+120, -120)
             // Future, higher resolution mouse wheels may report smaller deltas.
-            // So we sum the deltas and only act when we've exceeded WHEEL_DELTA
-            //
-            // If the user rapidly spins the wheel, we can get messages with
-            // large deltas, like 480 or so.  Thus we need to scroll more quickly.
+            // Accumulate into integer "clicks" only on WHEEL_DELTA crossings
+            // (unchanged discrete behavior), but always forward the raw
+            // per-message delta as the precise value so smooth consumers
+            // integrate sub-notch motion. See LLScrollDelta.
+            S32 clicks = 0;
             if (z_delta <= -WHEEL_DELTA || WHEEL_DELTA <= z_delta)
             {
-                short clicks = -z_delta / WHEEL_DELTA;
-                WINDOW_IMP_POST(window_imp->mCallbacks->handleScrollWheel(window_imp, clicks));
+                clicks = -z_delta / WHEEL_DELTA;
                 z_delta = 0;
             }
+            WINDOW_IMP_POST(window_imp->mCallbacks->handleScrollWheel(window_imp,
+                LLScrollDelta(clicks, -(F32)incoming_z_delta / (F32)WHEEL_DELTA)));
             return 0;
         }
         /*
@@ -2965,13 +2966,18 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             S16 incoming_h_delta = HIWORD(w_param);
             h_delta += incoming_h_delta;
 
-            // If the user rapidly spins the wheel, we can get messages with
-            // large deltas, like 480 or so.  Thus we need to scroll more quickly.
+            // Accumulate integer "clicks" on WHEEL_DELTA crossings (unchanged),
+            // but always forward the raw per-message delta as the precise value.
+            // No sign flip on the horizontal axis (matches the old
+            // h_delta / WHEEL_DELTA convention). See LLScrollDelta.
+            S32 h_clicks = 0;
             if (h_delta <= -WHEEL_DELTA || WHEEL_DELTA <= h_delta)
             {
-                WINDOW_IMP_POST(window_imp->mCallbacks->handleScrollHWheel(window_imp, h_delta / WHEEL_DELTA));
+                h_clicks = h_delta / WHEEL_DELTA;
                 h_delta = 0;
             }
+            WINDOW_IMP_POST(window_imp->mCallbacks->handleScrollHWheel(window_imp,
+                LLScrollDelta(h_clicks, (F32)incoming_h_delta / (F32)WHEEL_DELTA)));
             return 0;
         }
         // Handle mouse movement within the window

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -33,6 +33,7 @@
 // LLWindow library includes
 #include "llkeyboardwin32.h"
 #include "lldragdropwin32.h"
+#include "lldxhardware.h"
 #include "llpreeditor.h"
 #include "llwindowcallbacks.h"
 
@@ -4776,115 +4777,9 @@ void LLWindowWin32::LLWindowWin32Thread::checkDXMem()
 {
     if (!mGLReady || mGotGLBuffer) { return; }
 
-    if ((gGLManager.mHasAMDAssociations || gGLManager.mHasNVXGpuMemoryInfo) && gGLManager.mVRAM != 0)
-    { // OpenGL already told us the memory budget, don't ask DX
-        mGotGLBuffer = true;
-        return;
-    }
-
     pauseTimeout();
 
-    IDXGIFactory4* p_factory = nullptr;
-
-    HRESULT res = CreateDXGIFactory1(__uuidof(IDXGIFactory4), (void**)&p_factory);
-
-    if (FAILED(res))
-    {
-        LL_WARNS() << "CreateDXGIFactory1 failed: 0x" << std::hex << res << LL_ENDL;
-    }
-    else
-    {
-        IDXGIAdapter3* p_dxgi_adapter = nullptr;
-        UINT graphics_adapter_index = 0;
-        while (true)
-        {
-            res = p_factory->EnumAdapters(graphics_adapter_index, reinterpret_cast<IDXGIAdapter**>(&p_dxgi_adapter));
-            if (FAILED(res))
-            {
-                if (graphics_adapter_index == 0)
-                {
-                    LL_WARNS() << "EnumAdapters failed: 0x" << std::hex << res << LL_ENDL;
-                }
-            }
-            else
-            {
-                if (graphics_adapter_index == 0) // Should it check largest one isntead of first?
-                {
-                    DXGI_QUERY_VIDEO_MEMORY_INFO info;
-                    p_dxgi_adapter->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &info);
-
-                    // Alternatively use GetDesc from below to get adapter's memory
-                    UINT64 budget_mb = info.Budget / (1024 * 1024);
-                    if (gGLManager.mIsIntel)
-                    {
-                        U32Megabytes phys_mb = gSysMemory.getPhysicalMemoryKB();
-                        LL_WARNS() << "Physical memory: " << phys_mb << " MB" << LL_ENDL;
-
-                        if (phys_mb > 0)
-                        {
-                            if (gGLManager.mIsIntel)
-                            {
-                                // Intel uses 'shared' vram, cap it to 25% of total memory
-                                // Todo: consider a way of detecting integrated Intel and AMD
-                                budget_mb = llmin(budget_mb, (UINT64)(phys_mb * 0.25));
-                            }
-                            else
-                            {
-                                // More budget is generally better, but the way viewer
-                                // utilizes even dedicated VRAM leaves a footprint in RAM
-                                budget_mb = llmin(budget_mb, (UINT64)(phys_mb * 0.75));
-                            }
-                        }
-                        else
-                        {
-                            // if no data available, cap to 2Gb
-                            budget_mb = llmin(budget_mb, (UINT64)2048);
-                        }
-                    }
-                    if (gGLManager.mVRAM < (S32)budget_mb)
-                    {
-                        gGLManager.mVRAM = (S32)budget_mb;
-                        LL_INFOS("RenderInit") << "New VRAM Budget (DX9): " << gGLManager.mVRAM << " MB" << LL_ENDL;
-                    }
-                    else
-                    {
-                        LL_INFOS("RenderInit") << "VRAM Budget (DX9): " << budget_mb
-                            << " MB, current (WMI): " << gGLManager.mVRAM << " MB" << LL_ENDL;
-                    }
-                }
-
-                DXGI_ADAPTER_DESC desc;
-                p_dxgi_adapter->GetDesc(&desc);
-                std::wstring description_w((wchar_t*)desc.Description);
-                std::string description = ll_convert_wide_to_string(description_w);
-                LL_INFOS("Window") << "Graphics adapter index: " << graphics_adapter_index << ", "
-                    << "Description: " << description << ", "
-                    << "DeviceId: " << desc.DeviceId << ", "
-                    << "SubSysId: " << desc.SubSysId << ", "
-                    << "AdapterLuid: " << desc.AdapterLuid.HighPart << "_" << desc.AdapterLuid.LowPart << ", "
-                    << "DedicatedVideoMemory: " << desc.DedicatedVideoMemory / 1024 / 1024 << ", "
-                    << "DedicatedSystemMemory: " << desc.DedicatedSystemMemory / 1024 / 1024 << ", "
-                    << "SharedSystemMemory: " << desc.SharedSystemMemory / 1024 / 1024 << LL_ENDL;
-            }
-
-            if (p_dxgi_adapter)
-            {
-                p_dxgi_adapter->Release();
-                p_dxgi_adapter = NULL;
-            }
-            else
-            {
-                break;
-            }
-
-            graphics_adapter_index++;
-        }
-    }
-
-    if (p_factory)
-    {
-        p_factory->Release();
-    }
+    LLDXHardware::updateVRAMBudgetFromDXGI();
 
     mGotGLBuffer = true;
 

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -109,6 +109,15 @@ elseif(LINUX)
     )
 endif ()
 
+# Branded splash icon for the SDL splash screen (LLSplashScreenSDL loads this
+# PNG at runtime from app_settings). Staged on all platforms so the SDL build
+# finds it regardless of which backend the package ends up using.
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${BRANDING_SOURCE_DIR}/viewer/icons/${ICON_PATH}/alchemy_256.png"
+    "${CMAKE_CURRENT_SOURCE_DIR}/app_settings/alchemy_logo.png"
+  )
+
 if (HAVOK)
    # When using HAVOK_TPV, the library is precompiled, so no need for this
 

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1726,6 +1726,15 @@ if (WINDOWS)
          llwindebug.h
          )
 
+    if (USE_SDL_WINDOW)
+        # Unified SDL main-callbacks entry point shared with Linux/macOS.
+        # llappviewerwin32's native wWinMain is compiled out (LL_SDL_WINDOW);
+        # SDL_AppInit instantiates LLAppViewerWin32 to keep the Win32
+        # platform overrides.
+        list(APPEND viewer_SOURCE_FILES llappviewersdl.cpp)
+        list(APPEND viewer_HEADER_FILES llappviewersdl.h)
+    endif ()
+
     # Add resource files to the project.
     # viewerRes.rc is the only buildable file, but
     # the rest are all dependencies of it.

--- a/indra/newview/app_settings/key_bindings.xml
+++ b/indra/newview/app_settings/key_bindings.xml
@@ -18,6 +18,19 @@
     <binding key="PGDN" mask="NONE" command="push_down"/>
     <binding key="HOME" mask="NONE" command="toggle_fly"/>
 
+    <!-- Numpad: distinct KEY_PAD_* keys (see the NumpadControl setting). These
+         reach the avatar regardless of UI focus; +/- (Add/Subtract) zoom. -->
+    <binding key="PAD_UP" mask="NONE" command="push_forward"/>
+    <binding key="PAD_DOWN" mask="NONE" command="push_backward"/>
+    <binding key="PAD_LEFT" mask="NONE" command="slide_left"/>
+    <binding key="PAD_RIGHT" mask="NONE" command="slide_right"/>
+    <binding key="PAD_PGUP" mask="NONE" command="jump"/>
+    <binding key="PAD_PGDN" mask="NONE" command="push_down"/>
+    <binding key="PAD_HOME" mask="NONE" command="toggle_fly"/>
+    <binding key="PAD_CENTER" mask="NONE" command="stop_moving"/>
+    <binding key="Add" mask="NONE" command="pan_in"/>
+    <binding key="Subtract" mask="NONE" command="pan_out"/>
+
     <binding key="SPACE" mask="NONE" command="stop_moving"/>
     <binding key="ENTER" mask="NONE" command="start_chat"/>
     <binding key="DIVIDE" mask="NONE" command="start_gesture"/>
@@ -52,6 +65,19 @@
     <binding key="PGUP" mask="NONE" command="jump"/>
     <binding key="PGDN" mask="NONE" command="push_down"/>
     <binding key="HOME" mask="NONE" command="toggle_fly"/>
+
+    <!-- Numpad: distinct KEY_PAD_* keys (see the NumpadControl setting). These
+         reach the avatar regardless of UI focus; +/- (Add/Subtract) zoom. -->
+    <binding key="PAD_UP" mask="NONE" command="push_forward"/>
+    <binding key="PAD_DOWN" mask="NONE" command="push_backward"/>
+    <binding key="PAD_LEFT" mask="NONE" command="turn_left"/>
+    <binding key="PAD_RIGHT" mask="NONE" command="turn_right"/>
+    <binding key="PAD_PGUP" mask="NONE" command="jump"/>
+    <binding key="PAD_PGDN" mask="NONE" command="push_down"/>
+    <binding key="PAD_HOME" mask="NONE" command="toggle_fly"/>
+    <binding key="PAD_CENTER" mask="NONE" command="stop_moving"/>
+    <binding key="Add" mask="NONE" command="pan_in"/>
+    <binding key="Subtract" mask="NONE" command="pan_out"/>
 
     <!--Camera controls in third person on Alt-->
     <binding key="LEFT" mask="ALT" command="spin_around_cw"/>
@@ -172,6 +198,17 @@
     <binding key="E" mask="SHIFT" command="roll_right"/>
     <binding key="Q" mask="CTL_SHIFT" command="roll_reset"/>
     <binding key="E" mask="CTL_SHIFT" command="roll_reset"/>
+
+    <!-- Numpad camera controls while sitting (distinct KEY_PAD_* keys; see the
+         NumpadControl setting). +/- (Add/Subtract) dolly the camera. -->
+    <binding key="PAD_UP" mask="NONE" command="move_forward_sitting"/>
+    <binding key="PAD_DOWN" mask="NONE" command="move_backward_sitting"/>
+    <binding key="PAD_LEFT" mask="NONE" command="spin_around_cw_sitting"/>
+    <binding key="PAD_RIGHT" mask="NONE" command="spin_around_ccw_sitting"/>
+    <binding key="PAD_PGUP" mask="NONE" command="spin_over_sitting"/>
+    <binding key="PAD_PGDN" mask="NONE" command="spin_under_sitting"/>
+    <binding key="Add" mask="NONE" command="move_forward_sitting"/>
+    <binding key="Subtract" mask="NONE" command="move_backward_sitting"/>
   </sitting>
   <edit_avatar>
     <!--Avatar editing camera controls-->

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -2,6 +2,17 @@
 <llsd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="llsd.xsd">
     <map>
+        <key>NumpadControl</key>
+        <map>
+            <key>Comment</key>
+            <string>How the numeric keypad controls your avatar. 0 = behaves like the normal arrow keys; 1 = numpad moves the avatar when NumLock is off (types digits when on); 2 = numpad always moves the avatar regardless of NumLock (use if you have no NumLock key).</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>S32</string>
+            <key>Value</key>
+            <integer>1</integer>
+        </map>
         <key>AudioFAudioOutputDevice</key>
         <map>
             <key>Comment</key>

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -1103,6 +1103,17 @@
             <key>Value</key>
             <integer>0</integer>
         </map>
+        <key>MouseWheelScrollSensitivity</key>
+        <map>
+            <key>Comment</key>
+            <string>Multiplier for high-precision (smooth) mouse-wheel scroll and zoom speed: camera zoom, smooth list/container scrolling, minimap/world-map/preview zoom. 1.0 = default. Does not affect item steppers (spinners, menus, combo boxes).</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>F32</string>
+            <key>Value</key>
+            <real>1.0</real>
+        </map>
         <key>NearbyToastHeightRatio</key>
         <map>
             <key>Comment</key>

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -2283,7 +2283,7 @@ LLVector3 LLAgentCamera::getAvatarRootPosition()
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-void LLAgentCamera::handleScrollWheel(S32 clicks)
+void LLAgentCamera::handleScrollWheel(F32 clicks)
 {
     if (mCameraMode == CAMERA_MODE_FOLLOW && getFocusOnAvatar())
     {
@@ -2309,7 +2309,7 @@ void LLAgentCamera::handleScrollWheel(S32 clicks)
 
         if (selection->getObjectCount() && selection->getSelectType() == SELECT_TYPE_HUD)
         {
-            F32 zoom_factor = (F32)pow(0.8, -clicks);
+            F32 zoom_factor = (F32)pow(0.8f, -clicks);
             cameraZoomIn(zoom_factor);
         }
         else if (mFocusOnAvatar && (mCameraMode == CAMERA_MODE_THIRD_PERSON))

--- a/indra/newview/llagentcamera.h
+++ b/indra/newview/llagentcamera.h
@@ -282,7 +282,7 @@ public:
     // Zoom
     //--------------------------------------------------------------------
 public:
-    void            handleScrollWheel(S32 clicks);                          // Mousewheel driven zoom
+    void            handleScrollWheel(F32 clicks);                          // Mousewheel driven zoom
     void            cameraZoomIn(const F32 factor);                         // Zoom in by fraction of current distance
     F32             getCameraZoomFraction(bool get_third_person = false);   // Get camera zoom as fraction of minimum and maximum zoom
     void            setCameraZoomFraction(F32 fraction);                    // Set camera zoom as fraction of minimum and maximum zoom

--- a/indra/newview/llappviewersdl.cpp
+++ b/indra/newview/llappviewersdl.cpp
@@ -48,6 +48,15 @@
 #include "llsdl.h"
 #include "llwindowsdl.h"
 
+#if LL_WINDOWS
+#include "llwin32headers.h"     // GetCommandLineW
+#include "llappviewerwin32.h"   // LLAppViewerWin32, create_app_mutex, NVAPI session helpers
+#include <shlwapi.h>            // PathGetArgsW
+#if LL_VELOPACK
+#include "llvelopack.h"
+#endif
+#endif
+
 #if LL_DARWIN
 #include <sys/types.h>
 #include <unistd.h>
@@ -107,8 +116,13 @@ namespace
 {
     int gArgC = 0;
     char **gArgV = NULL;
-    LLAppViewerSDL* gViewerAppPtr = NULL;
+    // LLAppViewerWin32 on Windows (USE_SDL_WINDOW builds), LLAppViewerSDL elsewhere.
+    LLAppViewer* gViewerAppPtr = NULL;
     void (*gOldTerminateHandler)() = NULL;
+#if LL_WINDOWS
+    // NvDRSSessionHandle from ll_nvapi_session_create(), torn down in SDL_AppQuit.
+    void* gNvApiSession = nullptr;
+#endif
 #if LL_LINUX && LL_DBUS
     // Shared session-bus connection, owned for the lifetime of the process and
     // pumped from SDL_AppIterate so incoming GoSLURL method calls get dispatched.
@@ -564,6 +578,18 @@ void sdl_logger(void *userdata, int category, SDL_LogPriority priority, const ch
 
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
 {
+#if LL_WINDOWS && LL_VELOPACK
+    // Velopack MUST be initialized first - it may handle install/uninstall
+    // commands and exit the process before we do anything else.
+    if (!velopack_initialize())
+    {
+        // Velopack handled the invocation (install/uninstall hook); exit
+        // cleanly without ever constructing the app. Mirrors WINMAIN's
+        // `return 0` — SDL_AppQuit tolerates the null gViewerAppPtr.
+        return SDL_APP_SUCCESS;
+    }
+#endif
+
     // Call Tracy first thing to have it allocate memory
     // https://github.com/wolfpld/tracy/issues/196
     LL_PROFILER_FRAME_END;
@@ -574,7 +600,18 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
     gArgC = argc;
     gArgV = argv;
 
+#if LL_WINDOWS
+    // Note: gIconResource (consumed by the native LLWindowWin32 window proc)
+    // is not set here — SDL_RegisterApp sources the window-class icon from the
+    // exe's embedded RT_GROUP_ICON (branded ll_icon.ico) automatically.
+    //
+    // LLAppViewerWin32::initParseCommandLine parses a single command-tail
+    // string with no program name — the same shape WINMAIN's pCmdLine has —
+    // so hand it the tail of GetCommandLineW rather than re-joining argv.
+    gViewerAppPtr = new LLAppViewerWin32(ll_convert_wide_to_string(PathGetArgsW(GetCommandLineW())).c_str());
+#else
     gViewerAppPtr = new LLAppViewerSDL();
+#endif
 
     SDL_SetLogOutputFunction(&sdl_logger, nullptr);
 
@@ -592,7 +629,13 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
     // install unexpected exception handler
     gOldTerminateHandler = std::set_terminate(exceptionTerminateHandler);
 
+#if LL_WINDOWS
+    // Set a debug info flag to indicate if multiple instances are running.
+    bool found_other_instance = !create_app_mutex();
+    gDebugInfo["FoundOtherInstanceAtStartup"] = LLSD::Boolean(found_other_instance);
+#else
     unsetenv( "LD_PRELOAD" ); // <FS:ND/> Get rid of any preloading, we do not want this to happen during startup of plugins.
+#endif
 
     // This needs to be set as early as possible
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_NAME_STRING, LLVersionInfo::getInstance()->getChannel().c_str());
@@ -609,6 +652,12 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
         LL_WARNS() << "Application init failed." << LL_ENDL;
         return SDL_APP_FAILURE;
     }
+
+#if LL_WINDOWS
+    // Override NVIDIA driver-profile settings as needed. Reads
+    // gSavedSettings, so this must come after init().
+    gNvApiSession = ll_nvapi_session_create();
+#endif
 
     return SDL_APP_CONTINUE;
 }
@@ -666,7 +715,9 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 
 void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
-    if (!LLApp::isError())
+    // gViewerAppPtr is null when SDL_AppInit bailed before constructing the
+    // app (e.g. the Windows velopack install-hook path).
+    if (gViewerAppPtr && !LLApp::isError())
     {
         //
         // We don't want to do cleanup here if the error handler got called -
@@ -678,6 +729,11 @@ void SDL_AppQuit(void *appstate, SDL_AppResult result)
 
     delete gViewerAppPtr;
     gViewerAppPtr = nullptr;
+
+#if LL_WINDOWS
+    ll_nvapi_session_destroy(gNvApiSession);
+    gNvApiSession = nullptr;
+#endif
 }
 
 bool LLAppViewerSDL::init()
@@ -790,6 +846,7 @@ if(act.sa_sigaction != old_act.sa_sigaction) ++reset_count;
 #else
     // *NOTE:Mani there is a case for implementing this on the mac.
     // Linux doesn't need it to my knowledge.
+    // Windows has its own exception handling that doesn't use Unix signals at all.
     return true;
 #endif
 }
@@ -951,14 +1008,42 @@ bool LLAppViewerSDL::sendURLToOtherInstance(const std::string& url)
     // Services / Apple Events automatically — no IPC needed from us.
     return false;
 }
-#else // LL_DBUS
+#elif LL_WINDOWS
 bool LLAppViewerSDL::initSLURLHandler()
 {
-    return false; // not implemented without dbus
+    return false; // not required on Windows
 }
 bool LLAppViewerSDL::sendURLToOtherInstance(const std::string& url)
 {
-    return false; // not implemented without dbus
+    wchar_t window_class[256]; /* Flawfinder: ignore */ // Assume max length < 255 chars.
+    mbstowcs(window_class, sWindowClass, 255);
+    window_class[255] = 0;
+    // Use the class instead of the window name.
+    HWND other_window = FindWindow(window_class, NULL);
+
+    if (other_window != NULL)
+    {
+        LL_DEBUGS() << "Found other window with the name '" << getWindowTitle() << "'" << LL_ENDL;
+        COPYDATASTRUCT cds;
+        const S32      SLURL_MESSAGE_TYPE = 0;
+        cds.dwData                        = SLURL_MESSAGE_TYPE;
+        cds.cbData                        = static_cast<DWORD>(url.length()) + 1;
+        cds.lpData                        = (void*)url.c_str();
+
+        LRESULT msg_result = SendMessage(other_window, WM_COPYDATA, NULL, (LPARAM)&cds);
+        LL_DEBUGS() << "SendMessage(WM_COPYDATA) to other window '" << getWindowTitle() << "' returned " << msg_result << LL_ENDL;
+        return true;
+    }
+    return false;
+}
+#else // LL_DBUS
+bool LLAppViewerSDL::initSLURLHandler()
+{
+    return false; // not implemented
+}
+bool LLAppViewerSDL::sendURLToOtherInstance(const std::string& url)
+{
+    return false; // not implemented
 }
 #endif // LL_DBUS
 
@@ -968,7 +1053,9 @@ void LLAppViewerSDL::initCrashReporting(bool reportFreeze)
 
 bool LLAppViewerSDL::beingDebugged()
 {
-#if LL_DARWIN
+#if LL_WINDOWS
+    return IsDebuggerPresent() != 0;
+#elif LL_DARWIN
     int                 junk;
     int                 mib[4];
     struct kinfo_proc   info;
@@ -1097,7 +1184,30 @@ std::string LLAppViewerSDL::generateSerialNumber()
 {
     char serial_md5[MD5HEX_STR_SIZE];       // Flawfinder: ignore
     serial_md5[0] = 0;
-#if LL_DARWIN
+#if LL_WINDOWS
+    DWORD serial  = 0;
+    DWORD flags   = 0;
+    BOOL  success = GetVolumeInformation(L"C:\\",
+                                         NULL,    // volume name buffer
+                                         0,       // volume name buffer size
+                                         &serial, // volume serial
+                                         NULL,    // max component length
+                                         &flags,  // file system flags
+                                         NULL,    // file system name buffer
+                                         0);      // file system name buffer size
+    if (success)
+    {
+        LLMD5 md5;
+        md5.update((unsigned char*)&serial, sizeof(DWORD));
+        md5.finalize();
+        md5.hex_digest(serial_md5);
+    }
+    else
+    {
+        LL_WARNS() << "GetVolumeInformation failed" << LL_ENDL;
+    }
+    return serial_md5;
+#elif LL_DARWIN
     // JC: Sample code from http://developer.apple.com/technotes/tn/tn1103.html
     CFStringRef serialNumber = NULL;
     io_service_t    platformExpert = IOServiceGetMatchingService(kIOMainPortDefault,

--- a/indra/newview/llappviewersdl.cpp
+++ b/indra/newview/llappviewersdl.cpp
@@ -1032,9 +1032,17 @@ bool LLAppViewerSDL::sendURLToOtherInstance(const std::string& url)
         cds.cbData                        = static_cast<DWORD>(url.length()) + 1;
         cds.lpData                        = (void*)url.c_str();
 
-        LRESULT msg_result = SendMessage(other_window, WM_COPYDATA, NULL, (LPARAM)&cds);
-        LL_DEBUGS() << "SendMessage(WM_COPYDATA) to other window '" << getWindowTitle() << "' returned " << msg_result << LL_ENDL;
-        return true;
+        // SendMessageTimeout (not SendMessage) so a hung/busy primary instance
+        // can't block this instance's startup; SMTO_ABORTIFHUNG bails fast. Our
+        // WM_COPYDATA handler returns TRUE on receipt, so require both a
+        // successful send and a non-zero result before treating the URL as
+        // handed off — otherwise fall through (return false) and handle it here.
+        DWORD_PTR msg_result = 0;
+        LRESULT sent = SendMessageTimeout(other_window, WM_COPYDATA, NULL, (LPARAM)&cds,
+                                          SMTO_ABORTIFHUNG, 2000, &msg_result);
+        LL_DEBUGS() << "SendMessageTimeout(WM_COPYDATA) to other window '" << getWindowTitle()
+                    << "' sent=" << sent << " result=" << msg_result << LL_ENDL;
+        return sent != 0 && msg_result != 0;
     }
     return false;
 }

--- a/indra/newview/llappviewersdl.cpp
+++ b/indra/newview/llappviewersdl.cpp
@@ -633,7 +633,9 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
     // Set a debug info flag to indicate if multiple instances are running.
     bool found_other_instance = !create_app_mutex();
     gDebugInfo["FoundOtherInstanceAtStartup"] = LLSD::Boolean(found_other_instance);
-#else
+#elif LL_LINUX
+    // macOS injects via DYLD_INSERT_LIBRARIES, not LD_PRELOAD, so this is a
+    // Linux-only scrub (clearing LD_PRELOAD on Darwin did nothing).
     unsetenv( "LD_PRELOAD" ); // <FS:ND/> Get rid of any preloading, we do not want this to happen during startup of plugins.
 #endif
 

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -28,6 +28,10 @@
 
 #include "llappviewerwin32.h"
 
+#if !LL_SDL_WINDOW
+#include "llwindowwin32.h" // for gIconResource, set in the native WINMAIN below
+#endif
+
 #include "res/resource.h" // *FIX: for setting gIconResource.
 
 #include <WERAPI.H>     // for WerAddExcludedApplication()

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -26,20 +26,11 @@
 
 #include "llviewerprecompiledheaders.h"
 
-#include "llwin32headers.h"
-
-#include "llwindowwin32.h" // *FIX: for setting gIconResource.
-
 #include "llappviewerwin32.h"
 
-#include "llgl.h"
 #include "res/resource.h" // *FIX: for setting gIconResource.
 
-#include <fcntl.h>      //_O_APPEND
-#include <io.h>         //_open_osfhandle()
 #include <WERAPI.H>     // for WerAddExcludedApplication()
-#include <process.h>    // _spawnl()
-#include <tchar.h>      // For TCHAR support
 
 #include "llviewercontrol.h"
 #include "lldxhardware.h"
@@ -49,24 +40,17 @@
 
 #include <stdlib.h>
 
-#include "llweb.h"
-
-#include "llviewernetwork.h"
 #include "llmd5.h"
 #include "llfindlocale.h"
 
 #include "llcommandlineparser.h"
-#include "lltrans.h"
 
 #ifndef LL_RELEASE_FOR_DOWNLOAD
 #include "llwindebug.h"
 #endif
 
-#include "stringize.h"
 #include "lldir.h"
-#include "llerrorcontrol.h"
 
-#include <fstream>
 #include <exception>
 
 #include "llversioninfovars.h"
@@ -419,6 +403,50 @@ void ll_nvapi_init(NvDRSSessionHandle hSession)
     }
 }
 
+void* ll_nvapi_session_create()
+{
+    NvDRSSessionHandle hSession = 0;
+    static LLCachedControl<bool> use_nv_api(gSavedSettings, "NvAPICreateApplicationProfile", true);
+    if (use_nv_api)
+    {
+        NvAPI_Status status;
+
+        // Initialize NVAPI
+        status = NvAPI_Initialize();
+
+        if (status == NVAPI_OK)
+        {
+            // Create the session handle to access driver settings
+            status = NvAPI_DRS_CreateSession(&hSession);
+            if (status != NVAPI_OK)
+            {
+                nvapi_error(status);
+                hSession = 0;
+            }
+            else
+            {
+                //override driver setting as needed
+                ll_nvapi_init(hSession);
+            }
+        }
+    }
+    return hSession;
+}
+
+void ll_nvapi_session_destroy(void* session)
+{
+    // (NVAPI) (6) We clean up. This is analogous to doing a free()
+    if (session)
+    {
+        NvAPI_DRS_DestroySession(reinterpret_cast<NvDRSSessionHandle>(session));
+    }
+}
+
+// When USE_SDL_WINDOW is enabled on Windows the exe entry point is SDL's
+// generated wWinMain in llappviewersdl.cpp (SDL_MAIN_USE_CALLBACKS), which
+// drives LLAppViewerWin32 through the SDL_App* callbacks instead.
+#if !LL_SDL_WINDOW
+
 //#define DEBUGGING_SEH_FILTER 1
 #if DEBUGGING_SEH_FILTER
 #   define WINMAIN DebuggingWinMain
@@ -496,30 +524,7 @@ int APIENTRY WINMAIN(HINSTANCE hInstance,
         return -1;
     }
 
-    NvDRSSessionHandle hSession = 0;
-    static LLCachedControl<bool> use_nv_api(gSavedSettings, "NvAPICreateApplicationProfile", true);
-    if (use_nv_api)
-    {
-        NvAPI_Status status;
-
-        // Initialize NVAPI
-        status = NvAPI_Initialize();
-
-        if (status == NVAPI_OK)
-        {
-            // Create the session handle to access driver settings
-            status = NvAPI_DRS_CreateSession(&hSession);
-            if (status != NVAPI_OK)
-            {
-                nvapi_error(status);
-            }
-            else
-            {
-                //override driver setting as needed
-                ll_nvapi_init(hSession);
-            }
-        }
-    }
+    NvDRSSessionHandle hSession = reinterpret_cast<NvDRSSessionHandle>(ll_nvapi_session_create());
 
     // Have to wait until after logging is initialized to display LFH info
     if (num_heaps > 0)
@@ -577,12 +582,8 @@ int APIENTRY WINMAIN(HINSTANCE hInstance,
     delete viewer_app_ptr;
     viewer_app_ptr = NULL;
 
-    // (NVAPI) (6) We clean up. This is analogous to doing a free()
-    if (hSession)
-    {
-        NvAPI_DRS_DestroySession(hSession);
-        hSession = 0;
-    }
+    ll_nvapi_session_destroy(hSession);
+    hSession = 0;
 
     return 0;
 }
@@ -607,6 +608,8 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     }
 }
 #endif
+
+#endif // !LL_SDL_WINDOW
 
 void LLAppViewerWin32::disableWinErrorReporting()
 {

--- a/indra/newview/llappviewerwin32.h
+++ b/indra/newview/llappviewerwin32.h
@@ -67,4 +67,14 @@ private:
     bool mIsConsoleAllocated;
 };
 
+// Process-level setup shared between the native WinMain entry point and the
+// SDL main-callbacks driver (llappviewersdl.cpp) used when USE_SDL_WINDOW is
+// enabled on Windows.
+bool create_app_mutex();
+// Wraps NvAPI_Initialize + session creation + ll_nvapi_init, gated on the
+// NvAPICreateApplicationProfile setting; must run after LLAppViewer::init().
+// Returns an NvDRSSessionHandle as void* (null if disabled or unavailable).
+void* ll_nvapi_session_create();
+void ll_nvapi_session_destroy(void* session);
+
 #endif // LL_LLAPPVIEWERWIN32_H

--- a/indra/newview/llchiclet.cpp
+++ b/indra/newview/llchiclet.cpp
@@ -1028,13 +1028,13 @@ boost::signals2::connection LLChicletPanel::setChicletClickedCallback(
     return setCommitCallback(cb);
 }
 
-bool LLChicletPanel::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLChicletPanel::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    if(clicks > 0)
+    if(delta.mClicks > 0)
     {
         scrollRight();
     }
-    else
+    else if (delta.mClicks < 0)
     {
         scrollLeft();
     }

--- a/indra/newview/llchiclet.h
+++ b/indra/newview/llchiclet.h
@@ -778,7 +778,7 @@ protected:
     /**
      * Callback for mouse wheel scrolled, calls scrollRight() or scrollLeft()
      */
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
 
     /**
      * Notifies subscribers about click on chiclet.

--- a/indra/newview/llfasttimerview.cpp
+++ b/indra/newview/llfasttimerview.cpp
@@ -354,17 +354,17 @@ bool LLFastTimerView::handleToolTip(S32 x, S32 y, MASK mask)
     return LLFloater::handleToolTip(x, y, mask);
 }
 
-bool LLFastTimerView::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFastTimerView::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (x < mBarRect.mLeft)
     {
         // Inside mScrollBar and list of timers
-        mScrollBar->handleScrollWheel(x,y,clicks);
+        mScrollBar->handleScrollWheel(x,y,delta);
     }
     else
     {
     setPauseState(true);
-    mScrollIndex = llclamp( mScrollIndex + clicks,
+    mScrollIndex = llclamp( mScrollIndex + delta.mClicks,
                             0,
                             llmin((S32)mRecording.getNumRecordedPeriods(), (S32)mRecording.getNumRecordedPeriods() - MAX_VISIBLE_HISTORY));
     }

--- a/indra/newview/llfasttimerview.h
+++ b/indra/newview/llfasttimerview.h
@@ -61,7 +61,7 @@ public:
     virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
     virtual bool handleHover(S32 x, S32 y, MASK mask);
     virtual bool handleToolTip(S32 x, S32 y, MASK mask);
-    virtual bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+    virtual bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
     virtual void draw();
     virtual void onOpen(const LLSD& key);
     virtual void onClose(bool app_quitting);

--- a/indra/newview/llfloaterbvhpreview.cpp
+++ b/indra/newview/llfloaterbvhpreview.cpp
@@ -534,7 +534,7 @@ bool LLFloaterBvhPreview::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
     if (!mAnimPreview)
         return false;
 
-    mAnimPreview->zoom((F32)delta.mClicks * -0.2f);
+    mAnimPreview->zoom((F32)delta.mPrecise * -0.2f);
     mAnimPreview->requestUpdate();
 
     return true;

--- a/indra/newview/llfloaterbvhpreview.cpp
+++ b/indra/newview/llfloaterbvhpreview.cpp
@@ -529,12 +529,12 @@ bool LLFloaterBvhPreview::handleHover(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-bool LLFloaterBvhPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterBvhPreview::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (!mAnimPreview)
         return false;
 
-    mAnimPreview->zoom((F32)clicks * -0.2f);
+    mAnimPreview->zoom((F32)delta.mClicks * -0.2f);
     mAnimPreview->requestUpdate();
 
     return true;

--- a/indra/newview/llfloaterbvhpreview.h
+++ b/indra/newview/llfloaterbvhpreview.h
@@ -78,7 +78,7 @@ public:
     bool handleMouseDown(S32 x, S32 y, MASK mask);
     bool handleMouseUp(S32 x, S32 y, MASK mask);
     bool handleHover(S32 x, S32 y, MASK mask);
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
     void onMouseCaptureLost();
 
     void refresh();

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -672,14 +672,14 @@ bool LLFloaterImagePreview::handleHover(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-bool LLFloaterImagePreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterImagePreview::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mPreviewRect.pointInRect(x, y) && mAvatarPreview)
     {
-        mAvatarPreview->zoom((F32)clicks * -0.2f);
+        mAvatarPreview->zoom((F32)delta.mClicks * -0.2f);
         mAvatarPreview->refresh();
 
-        mSculptedPreview->zoom((F32)clicks * -0.2f);
+        mSculptedPreview->zoom((F32)delta.mClicks * -0.2f);
         mSculptedPreview->refresh();
     }
 

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -676,10 +676,10 @@ bool LLFloaterImagePreview::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mPreviewRect.pointInRect(x, y) && mAvatarPreview)
     {
-        mAvatarPreview->zoom((F32)delta.mClicks * -0.2f);
+        mAvatarPreview->zoom((F32)delta.mPrecise * -0.2f);
         mAvatarPreview->refresh();
 
-        mSculptedPreview->zoom((F32)delta.mClicks * -0.2f);
+        mSculptedPreview->zoom((F32)delta.mPrecise * -0.2f);
         mSculptedPreview->refresh();
     }
 

--- a/indra/newview/llfloaterimagepreview.h
+++ b/indra/newview/llfloaterimagepreview.h
@@ -120,7 +120,7 @@ public:
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleMouseUp(S32 x, S32 y, MASK mask) override;
     bool handleHover(S32 x, S32 y, MASK mask) override;
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
 
     static void onMouseCaptureLostImagePreview(LLMouseHandler*);
 

--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -945,7 +945,7 @@ bool LLFloaterModelPreview::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mPreviewRect.pointInRect(x, y) && mModelPreview)
     {
-        mModelPreview->zoom((F32)delta.mClicks * -0.2f);
+        mModelPreview->zoom((F32)delta.mPrecise * -0.2f);
         mModelPreview->refresh();
     }
     else

--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -941,16 +941,16 @@ bool LLFloaterModelPreview::handleHover (S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-bool LLFloaterModelPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterModelPreview::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mPreviewRect.pointInRect(x, y) && mModelPreview)
     {
-        mModelPreview->zoom((F32)clicks * -0.2f);
+        mModelPreview->zoom((F32)delta.mClicks * -0.2f);
         mModelPreview->refresh();
     }
     else
     {
-        LLFloaterModelUploadBase::handleScrollWheel(x, y, clicks);
+        LLFloaterModelUploadBase::handleScrollWheel(x, y, delta);
     }
     return true;
 }

--- a/indra/newview/llfloatermodelpreview.h
+++ b/indra/newview/llfloatermodelpreview.h
@@ -79,7 +79,7 @@ public:
     bool handleMouseDown(S32 x, S32 y, MASK mask);
     bool handleMouseUp(S32 x, S32 y, MASK mask);
     bool handleHover(S32 x, S32 y, MASK mask);
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
 
     /*virtual*/ void onOpen(const LLSD& key);
     /*virtual*/ void onClose(bool app_quitting);

--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -580,7 +580,7 @@ bool LLFloaterWorldMap::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
         if (mMapView->pointInView(map_x, map_y))
         {
             F32 old_slider_zoom = (F32) mZoomSlider->getValue().asReal();
-            F32 slider_zoom     = old_slider_zoom + ((F32) delta.mClicks * -0.3333f);
+            F32 slider_zoom     = old_slider_zoom + ((F32) delta.mPrecise * -0.3333f);
             mZoomSlider->setValue(LLSD(slider_zoom));
             mMapView->zoomWithPivot(slider_zoom, map_x, map_y);
             return true;

--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -571,7 +571,7 @@ bool LLFloaterWorldMap::handleHover(S32 x, S32 y, MASK mask)
     return handled;
 }
 
-bool LLFloaterWorldMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterWorldMap::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (!isMinimized() && isFrontmost())
     {
@@ -580,14 +580,14 @@ bool LLFloaterWorldMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
         if (mMapView->pointInView(map_x, map_y))
         {
             F32 old_slider_zoom = (F32) mZoomSlider->getValue().asReal();
-            F32 slider_zoom     = old_slider_zoom + ((F32) clicks * -0.3333f);
+            F32 slider_zoom     = old_slider_zoom + ((F32) delta.mClicks * -0.3333f);
             mZoomSlider->setValue(LLSD(slider_zoom));
             mMapView->zoomWithPivot(slider_zoom, map_x, map_y);
             return true;
         }
     }
 
-    return LLFloater::handleScrollWheel(x, y, clicks);
+    return LLFloater::handleScrollWheel(x, y, delta);
 }
 
 

--- a/indra/newview/llfloaterworldmap.h
+++ b/indra/newview/llfloaterworldmap.h
@@ -88,7 +88,7 @@ public:
 
     /*virtual*/ void reshape( S32 width, S32 height, bool called_from_parent = true );
     /*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
-    /*virtual*/ bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ void draw();
 
     /*virtual*/ void onFocusLost();

--- a/indra/newview/llfollowcam.cpp
+++ b/indra/newview/llfollowcam.cpp
@@ -510,20 +510,26 @@ void LLFollowCam::setSubjectPositionAndRotation( const LLVector3 p, const LLQuat
 
 
 //---------------------------------------------------------
-void LLFollowCam::zoom( S32 z )
+void LLFollowCam::zoom( F32 z )
 {
     F32 zoomAmount = z * mSimulatedDistance * FOLLOW_CAM_ZOOM_FACTOR;
 
-    if (( zoomAmount <  FOLLOW_CAM_MIN_ZOOM_AMOUNT )
-    &&  ( zoomAmount > -FOLLOW_CAM_MIN_ZOOM_AMOUNT ))
+    // Guarantee a full wheel notch always zooms a perceptible amount, but
+    // scale that floor by |z| so sub-notch precise scrolling (high-res wheels
+    // / touchpads) zooms smoothly instead of snapping every fractional event
+    // up to the whole-notch minimum. A whole notch (|z| >= 1) keeps the
+    // original FOLLOW_CAM_MIN_ZOOM_AMOUNT.
+    F32 minZoomAmount = FOLLOW_CAM_MIN_ZOOM_AMOUNT * llmin(1.f, fabsf(z));
+    if (( zoomAmount <  minZoomAmount )
+    &&  ( zoomAmount > -minZoomAmount ))
     {
         if ( zoomAmount < 0.0f )
         {
-            zoomAmount = -FOLLOW_CAM_MIN_ZOOM_AMOUNT;
+            zoomAmount = -minZoomAmount;
         }
         else
         {
-            zoomAmount = FOLLOW_CAM_MIN_ZOOM_AMOUNT;
+            zoomAmount = minZoomAmount;
         }
     }
 

--- a/indra/newview/llfollowcam.h
+++ b/indra/newview/llfollowcam.h
@@ -147,7 +147,7 @@ public:
     void setMaxCameraDistantFromSubject ( F32 m ); // this should be determined by llAgent
     bool isZoomedToMinimumDistance();
     LLVector3   getUpVector();
-    void zoom( S32 );
+    void zoom( F32 );
 
     // overrides for setters and getters
     virtual void setPitch( F32 );

--- a/indra/newview/llhexeditor.cpp
+++ b/indra/newview/llhexeditor.cpp
@@ -280,9 +280,9 @@ U32 LLHexEditor::getProperSelectionEnd() const
     return (mSelectionStart < mSelectionEnd) ? mSelectionEnd : mSelectionStart;
 }
 
-bool LLHexEditor::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLHexEditor::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return mScrollbar->handleScrollWheel( 0, 0, clicks );
+    return mScrollbar->handleScrollWheel( 0, 0, delta );
 }
 
 bool LLHexEditor::handleMouseDown(S32 x, S32 y, MASK mask)

--- a/indra/newview/llhexeditor.h
+++ b/indra/newview/llhexeditor.h
@@ -42,7 +42,7 @@ public:
     void reshape(S32 width, S32 height, bool called_from_parent) override;
     void setFocus(bool b) override;
 
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleHover(S32 x, S32 y, MASK mask) override;
     bool handleMouseUp(S32 x, S32 y, MASK mask) override;

--- a/indra/newview/llmachineid.cpp
+++ b/indra/newview/llmachineid.cpp
@@ -113,9 +113,21 @@ void LLWMIMethods::initCOMObjects()
 
     if (FAILED(mHR))
     {
-        LL_WARNS("AppInit") << "Failed to initialize security. Error code = 0x" << std::hex << mHR << LL_ENDL;
-        CoUninitialize();
-        return;               // Program has failed.
+        // RPC_E_TOO_LATE means process-wide COM security was already initialized
+        // before we got here — which is harmless, WMI works with the existing
+        // settings. This happens under the SDL window backend, where SDL brings
+        // COM up during video init (and DXGI/DirectInput marshal interfaces)
+        // before machine-id generation runs. Only a genuine failure is fatal.
+        if (mHR == RPC_E_TOO_LATE)
+        {
+            LL_DEBUGS("AppInit") << "COM security already initialized; continuing with existing settings." << LL_ENDL;
+        }
+        else
+        {
+            LL_WARNS("AppInit") << "Failed to initialize security. Error code = 0x" << std::hex << mHR << LL_ENDL;
+            CoUninitialize();
+            return;               // Program has failed.
+        }
     }
 
     // Step 3: ---------------------------------------------------

--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -206,13 +206,13 @@ bool LLMediaCtrl::handleHover( S32 x, S32 y, MASK mask )
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-bool LLMediaCtrl::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLMediaCtrl::handleScrollWheel( S32 x, S32 y, LLScrollDelta delta )
 {
-    if (LLPanel::handleScrollWheel(x, y, clicks)) return true;
+    if (LLPanel::handleScrollWheel(x, y, delta)) return true;
     if (mMediaSource && mMediaSource->hasMedia())
     {
         convertInputCoords(x, y);
-        mMediaSource->scrollWheel(x, y, 0, clicks, gKeyboard->currentMask(true));
+        mMediaSource->scrollWheel(x, y, 0, delta.mClicks, gKeyboard->currentMask(true));
     }
 
     return true;
@@ -220,13 +220,13 @@ bool LLMediaCtrl::handleScrollWheel( S32 x, S32 y, S32 clicks )
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-bool LLMediaCtrl::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLMediaCtrl::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    if (LLPanel::handleScrollHWheel(x, y, clicks)) return true;
+    if (LLPanel::handleScrollHWheel(x, y, delta)) return true;
     if (mMediaSource && mMediaSource->hasMedia())
     {
         convertInputCoords(x, y);
-        mMediaSource->scrollWheel(x, y, clicks, 0, gKeyboard->currentMask(true));
+        mMediaSource->scrollWheel(x, y, delta.mClicks, 0, gKeyboard->currentMask(true));
     }
 
     return true;

--- a/indra/newview/llmediactrl.h
+++ b/indra/newview/llmediactrl.h
@@ -94,8 +94,8 @@ public:
         virtual bool handleMiddleMouseDown(S32 x, S32 y, MASK mask);
         virtual bool handleMiddleMouseUp(S32 x, S32 y, MASK mask);
         virtual bool handleDoubleClick( S32 x, S32 y, MASK mask );
-        virtual bool handleScrollWheel( S32 x, S32 y, S32 clicks );
-        virtual bool handleScrollHWheel( S32 x, S32 y, S32 clicks );
+        virtual bool handleScrollWheel( S32 x, S32 y, LLScrollDelta delta );
+        virtual bool handleScrollHWheel( S32 x, S32 y, LLScrollDelta delta );
         virtual bool handleToolTip(S32 x, S32 y, MASK mask);
 
         // navigation

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -836,7 +836,7 @@ LLVector3d LLNetMap::viewPosToGlobal( S32 x, S32 y )
 bool LLNetMap::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     // note that clicks are reversed from what you'd think: i.e. > 0  means zoom out, < 0 means zoom in
-    F32 new_scale = mScale * (F32)pow(MAP_SCALE_ZOOM_FACTOR, -delta.mClicks);
+    F32 new_scale = mScale * (F32)pow(MAP_SCALE_ZOOM_FACTOR, -delta.mPrecise);
     F32 old_scale = mScale;
 
     setScale(new_scale);

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -833,10 +833,10 @@ LLVector3d LLNetMap::viewPosToGlobal( S32 x, S32 y )
     return pos_global;
 }
 
-bool LLNetMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLNetMap::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     // note that clicks are reversed from what you'd think: i.e. > 0  means zoom out, < 0 means zoom in
-    F32 new_scale = mScale * (F32)pow(MAP_SCALE_ZOOM_FACTOR, -clicks);
+    F32 new_scale = mScale * (F32)pow(MAP_SCALE_ZOOM_FACTOR, -delta.mClicks);
     F32 old_scale = mScale;
 
     setScale(new_scale);

--- a/indra/newview/llnetmap.h
+++ b/indra/newview/llnetmap.h
@@ -71,7 +71,7 @@ public:
     static const F32 MAP_SCALE_MAX;
 
     /*virtual*/ void    draw();
-    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ bool    handleMouseDown(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleMouseUp(S32 x, S32 y, MASK mask);
     /*virtual*/ bool    handleHover( S32 x, S32 y, MASK mask );

--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -254,12 +254,12 @@ bool LLPanelEmojiComplete::handleMouseUp(S32 x, S32 y, MASK mask)
     return true;
 }
 
-bool LLPanelEmojiComplete::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelEmojiComplete::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if (mNoScroll)
         return false;
 
-    if (mScrollbar && mScrollbar->getVisible() && mScrollbar->handleScrollWheel(x, y, clicks))
+    if (mScrollbar && mScrollbar->getVisible() && mScrollbar->handleScrollWheel(x, y, delta))
     {
         mCurSelected = posToIndex(x, y);
         return true;
@@ -270,7 +270,7 @@ bool LLPanelEmojiComplete::handleScrollWheel(S32 x, S32 y, S32 clicks)
         // In case of wheel up (clicks < 0) we shouldn't subtract more than value of mScrollPos
         // Example: if mScrollPos = 0, clicks = -1 then (mScrollPos + clicks) becomes SIZE_MAX
         // As a result of llclamp<size_t>() mScrollPos becomes (mTotalEmojis - mVisibleEmojis)
-        S32 newScrollPos = llmax(0, (S32)mScrollPos + clicks);
+        S32 newScrollPos = llmax(0, (S32)mScrollPos + delta.mClicks);
         mScrollPos = llclamp<size_t>((size_t)newScrollPos, 0, mTotalEmojis - mVisibleEmojis);
         mCurSelected = posToIndex(x, y);
         return true;

--- a/indra/newview/llpanelemojicomplete.h
+++ b/indra/newview/llpanelemojicomplete.h
@@ -64,7 +64,7 @@ public:
     bool handleKey(KEY key, MASK mask, bool called_from_parent) override;
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleMouseUp(S32 x, S32 y, MASK mask) override;
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
     void onCommit() override;
     void reshape(S32 width, S32 height, bool called_from_parent) override;
 

--- a/indra/newview/llpanelprimmediacontrols.cpp
+++ b/indra/newview/llpanelprimmediacontrols.cpp
@@ -833,7 +833,7 @@ void LLPanelPrimMediaControls::draw()
     }
 }
 
-bool LLPanelPrimMediaControls::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelPrimMediaControls::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     mInactivityTimer.start();
     bool res = false;
@@ -843,13 +843,13 @@ bool LLPanelPrimMediaControls::handleScrollWheel(S32 x, S32 y, S32 clicks)
     if (LLViewerMediaFocus::getInstance()->isHoveringOverFocused())
     {
         // either let toolpie handle this or expose mHoverPick.mUVCoords in some way
-        res = LLToolPie::getInstance()->handleScrollWheel(x, y, clicks);
+        res = LLToolPie::getInstance()->handleScrollWheel(x, y, delta);
     }
 
     return res;
 }
 
-bool LLPanelPrimMediaControls::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelPrimMediaControls::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     mInactivityTimer.start();
     bool res = false;
@@ -857,7 +857,7 @@ bool LLPanelPrimMediaControls::handleScrollHWheel(S32 x, S32 y, S32 clicks)
     if (LLViewerMediaFocus::getInstance()->isHoveringOverFocused())
     {
         // either let toolpie handle this or expose mHoverPick.mUVCoords in some way
-        res = LLToolPie::getInstance()->handleScrollHWheel(x, y, clicks);
+        res = LLToolPie::getInstance()->handleScrollHWheel(x, y, delta);
     }
 
     return res;

--- a/indra/newview/llpanelprimmediacontrols.h
+++ b/indra/newview/llpanelprimmediacontrols.h
@@ -48,8 +48,8 @@ public:
     virtual ~LLPanelPrimMediaControls();
     bool postBuild() override;
     void draw() override;
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
-    bool handleScrollHWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
+    bool handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta) override;
 
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleMouseUp(S32 x, S32 y, MASK mask) override;

--- a/indra/newview/llpanelpulldown.cpp
+++ b/indra/newview/llpanelpulldown.cpp
@@ -76,9 +76,9 @@ bool LLPanelPulldown::handleDoubleClick(S32 x, S32 y, MASK mask)
     return true;
 }
 
-bool LLPanelPulldown::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelPulldown::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    LLPanel::handleScrollWheel(x, y, clicks);
+    LLPanel::handleScrollWheel(x, y, delta);
     return true; //If we got here, then we are in Pulldown's rect, consume the event.
 }
 

--- a/indra/newview/llpanelpulldown.h
+++ b/indra/newview/llpanelpulldown.h
@@ -42,7 +42,7 @@ public:
     bool handleMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleRightMouseDown(S32 x, S32 y, MASK mask) override;
     bool handleDoubleClick(S32 x, S32 y, MASK mask) override;
-    bool handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
     void onTopLost() override;
     void onVisibilityChange(bool new_visibility) override;
 

--- a/indra/newview/llpopupview.cpp
+++ b/indra/newview/llpopupview.cpp
@@ -216,12 +216,12 @@ bool LLPopupView::handleHover(S32 x, S32 y, MASK mask)
     return handled;
 }
 
-bool LLPopupView::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPopupView::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleScrollWheel, _1, _2, _3, clicks), view_visible_and_enabled, x, y, false);
+    bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleScrollWheel, _1, _2, _3, delta), view_visible_and_enabled, x, y, false);
     if (!handled)
     {
-        handled = LLPanel::handleScrollWheel(x, y, clicks);
+        handled = LLPanel::handleScrollWheel(x, y, delta);
     }
     return handled;
 }

--- a/indra/newview/llpopupview.h
+++ b/indra/newview/llpopupview.h
@@ -44,7 +44,7 @@ public:
     /*virtual*/ bool handleRightMouseUp(S32 x, S32 y, MASK mask);
     /*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
     /*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
-    /*virtual*/ bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
     /*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
 
     void addPopup(LLView* popup);

--- a/indra/newview/lltool.cpp
+++ b/indra/newview/lltool.cpp
@@ -108,14 +108,14 @@ bool LLTool::handleHover(S32 x, S32 y, MASK mask)
     return true;
 }
 
-bool LLTool::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLTool::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     // by default, didn't handle it
     // LL_INFOS() << "LLTool::handleScrollWheel" << LL_ENDL;
     return false;
 }
 
-bool LLTool::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLTool::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     // by default, didn't handle it
     return false;

--- a/indra/newview/lltool.h
+++ b/indra/newview/lltool.h
@@ -56,8 +56,8 @@ public:
     virtual bool    handleMiddleMouseUp(S32 x, S32 y, MASK mask);
 
     virtual bool    handleHover(S32 x, S32 y, MASK mask);
-    virtual bool    handleScrollWheel(S32 x, S32 y, S32 clicks);
-    virtual bool    handleScrollHWheel(S32 x, S32 y, S32 clicks);
+    virtual bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta);
+    virtual bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta);
     virtual bool    handleDoubleClick(S32 x, S32 y, MASK mask);
     virtual bool    handleRightMouseDown(S32 x, S32 y, MASK mask);
     virtual bool    handleRightMouseUp(S32 x, S32 y, MASK mask);

--- a/indra/newview/lltoolcomp.cpp
+++ b/indra/newview/lltoolcomp.cpp
@@ -876,9 +876,9 @@ bool LLToolCompGun::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 
         gSavedPerAccountSettings.setF32(
             "AlchemyMouselookAlternativeFOV",
-            mTargetFOV = delta.mClicks > 0 ?
-                llclamp(mTargetFOV += (0.05f * delta.mClicks), 0.1f, 3.0f) :
-                llclamp(mTargetFOV -= (0.05f * -delta.mClicks), 0.1f, 3.0f)
+            mTargetFOV = delta.mPrecise > 0 ?
+                llclamp(mTargetFOV += (0.05f * delta.mPrecise), 0.1f, 3.0f) :
+                llclamp(mTargetFOV -= (0.05f * -delta.mPrecise), 0.1f, 3.0f)
         );
 
         mTimerFOV.start();

--- a/indra/newview/lltoolcomp.cpp
+++ b/indra/newview/lltoolcomp.cpp
@@ -868,7 +868,7 @@ void    LLToolCompGun::handleDeselect()
 }
 
 
-bool LLToolCompGun::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLToolCompGun::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
     if(mRightMouseDown)
     {
@@ -876,14 +876,14 @@ bool LLToolCompGun::handleScrollWheel(S32 x, S32 y, S32 clicks)
 
         gSavedPerAccountSettings.setF32(
             "AlchemyMouselookAlternativeFOV",
-            mTargetFOV = clicks > 0 ?
-                llclamp(mTargetFOV += (0.05f * clicks), 0.1f, 3.0f) :
-                llclamp(mTargetFOV -= (0.05f * -clicks), 0.1f, 3.0f)
+            mTargetFOV = delta.mClicks > 0 ?
+                llclamp(mTargetFOV += (0.05f * delta.mClicks), 0.1f, 3.0f) :
+                llclamp(mTargetFOV -= (0.05f * -delta.mClicks), 0.1f, 3.0f)
         );
 
         mTimerFOV.start();
     }
-    else if (clicks > 0)
+    else if (delta.mClicks > 0)
     {
         gAgentCamera.changeCameraToDefault();
     }

--- a/indra/newview/lltoolcomp.h
+++ b/indra/newview/lltoolcomp.h
@@ -51,7 +51,7 @@ public:
 
     // Map virtual functions to the currently active internal tool
     virtual bool            handleHover(S32 x, S32 y, MASK mask)            { return mCur->handleHover( x, y, mask ); }
-    virtual bool            handleScrollWheel(S32 x, S32 y, S32 clicks)     { return mCur->handleScrollWheel( x, y, clicks ); }
+    virtual bool            handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)     { return mCur->handleScrollWheel( x, y, delta ); }
     virtual bool            handleRightMouseDown(S32 x, S32 y, MASK mask)   { return mCur->handleRightMouseDown( x, y, mask ); }
     virtual bool            handleRightMouseUp(S32 x, S32 y, MASK mask)     { return mCur->handleRightMouseUp( x, y, mask ); }
 
@@ -236,7 +236,7 @@ public:
     virtual bool            handleRightMouseDown(S32 x, S32 y, MASK mask) override;
     virtual bool            handleRightMouseUp(S32 x, S32 y, MASK mask) override;
     virtual bool            handleMouseUp(S32 x, S32 y, MASK mask) override;
-    virtual bool            handleScrollWheel(S32 x, S32 y, S32 clicks) override;
+    virtual bool            handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
     virtual void            onMouseCaptureLost() override;
     virtual void            handleSelect() override;
     virtual void            handleDeselect() override;

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -229,14 +229,14 @@ bool LLToolPie::handleScrollWheelAny(S32 x, S32 y, S32 clicks_x, S32 clicks_y)
     return res;
 }
 
-bool LLToolPie::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLToolPie::handleScrollWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return handleScrollWheelAny(x, y, 0, clicks);
+    return handleScrollWheelAny(x, y, 0, delta.mClicks);
 }
 
-bool LLToolPie::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLToolPie::handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta)
 {
-    return handleScrollWheelAny(x, y, clicks, 0);
+    return handleScrollWheelAny(x, y, delta.mClicks, 0);
 }
 
 // True if you selected an object.

--- a/indra/newview/lltoolpie.h
+++ b/indra/newview/lltoolpie.h
@@ -50,8 +50,8 @@ public:
     virtual bool        handleHover(S32 x, S32 y, MASK mask) override;
     virtual bool        handleDoubleClick(S32 x, S32 y, MASK mask) override;
     bool                handleScrollWheelAny(S32 x, S32 y, S32 clicks_x, S32 clicks_y);
-    virtual bool        handleScrollWheel(S32 x, S32 y, S32 clicks) override;
-    virtual bool        handleScrollHWheel(S32 x, S32 y, S32 clicks) override;
+    virtual bool        handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) override;
+    virtual bool        handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta) override;
     virtual bool        handleToolTip(S32 x, S32 y, MASK mask) override;
 
     virtual void        render() override;

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -189,6 +189,15 @@ static bool handleAvatarHoverOffsetChanged(const LLSD& newvalue)
     return true;
 }
 
+static bool handleNumpadControlChanged(const LLSD& newvalue)
+{
+    if (gKeyboard)
+    {
+        gKeyboard->setNumpadDistinct(static_cast<LLKeyboard::e_numpad_distinct>(newvalue.asInteger()));
+    }
+    return true;
+}
+
 
 static bool handleSetShaderChanged(const LLSD& newvalue)
 {
@@ -957,6 +966,7 @@ void settings_setup_listeners()
 {
     LL_PROFILE_ZONE_SCOPED;
     setting_setup_signal_listener(gSavedSettings, "FirstPersonAvatarVisible", handleRenderAvatarMouselookChanged);
+    setting_setup_signal_listener(gSavedSettings, "NumpadControl", handleNumpadControlChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderFarClip", handleRenderFarClipChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderTerrainScale", handleTerrainScaleChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderTerrainPBRScale", handlePBRTerrainScaleChanged);

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -193,7 +193,10 @@ static bool handleNumpadControlChanged(const LLSD& newvalue)
 {
     if (gKeyboard)
     {
-        gKeyboard->setNumpadDistinct(static_cast<LLKeyboard::e_numpad_distinct>(newvalue.asInteger()));
+        // Clamp persisted/out-of-range values to the valid enum range so an
+        // edited settings file can't push the keyboard into an undefined mode.
+        S32 mode = llclamp(newvalue.asInteger(), (S32)LLKeyboard::ND_NEVER, (S32)LLKeyboard::ND_NUMLOCK_ON);
+        gKeyboard->setNumpadDistinct(static_cast<LLKeyboard::e_numpad_distinct>(mode));
     }
     return true;
 }

--- a/indra/newview/llviewermedia.h
+++ b/indra/newview/llviewermedia.h
@@ -328,8 +328,8 @@ public:
     // Sadly, these are all pure virtual, so I have to supply implementations here:
     /*virtual*/ bool    handleMouseDown(S32 x, S32 y, MASK mask) { return false; };
     /*virtual*/ bool    handleHover(S32 x, S32 y, MASK mask) { return false; };
-    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, S32 clicks) { return false; };
-    /*virtual*/ bool    handleScrollHWheel(S32 x, S32 y, S32 clicks) { return false; };
+    /*virtual*/ bool    handleScrollWheel(S32 x, S32 y, LLScrollDelta delta) { return false; };
+    /*virtual*/ bool    handleScrollHWheel(S32 x, S32 y, LLScrollDelta delta) { return false; };
     /*virtual*/ bool    handleDoubleClick(S32 x, S32 y, MASK mask) { return false; };
     /*virtual*/ bool    handleRightMouseDown(S32 x, S32 y, MASK mask) { return false; };
     /*virtual*/ bool    handleRightMouseUp(S32 x, S32 y, MASK mask) { return false; };

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1994,14 +1994,14 @@ bool LLViewerWindow::handlePaint(LLWindow *window,  S32 x,  S32 y, S32 width,  S
 }
 
 
-void LLViewerWindow::handleScrollWheel(LLWindow *window,  S32 clicks)
+void LLViewerWindow::handleScrollWheel(LLWindow *window,  LLScrollDelta delta)
 {
-    handleScrollWheel( clicks );
+    handleScrollWheel( delta );
 }
 
-void LLViewerWindow::handleScrollHWheel(LLWindow *window,  S32 clicks)
+void LLViewerWindow::handleScrollHWheel(LLWindow *window,  LLScrollDelta delta)
 {
-    handleScrollHWheel(clicks);
+    handleScrollHWheel(delta);
 }
 
 void LLViewerWindow::handleWindowBlock(LLWindow *window)
@@ -3485,7 +3485,7 @@ bool LLViewerWindow::handleUnicodeChar(llwchar uni_char, MASK mask)
 }
 
 
-void LLViewerWindow::handleScrollWheel(S32 clicks)
+void LLViewerWindow::handleScrollWheel(LLScrollDelta delta)
 {
     LLUI::getInstance()->resetMouseIdleTimer();
 
@@ -3495,7 +3495,7 @@ void LLViewerWindow::handleScrollWheel(S32 clicks)
         S32 local_x;
         S32 local_y;
         mouse_captor->screenPointToLocal( mCurrentMousePoint.mX, mCurrentMousePoint.mY, &local_x, &local_y );
-        mouse_captor->handleScrollWheel(local_x, local_y, clicks);
+        mouse_captor->handleScrollWheel(local_x, local_y, delta);
         if (LLView::sDebugMouseHandling)
         {
             LL_INFOS() << "Scroll Wheel handled by captor " << mouse_captor->getName() << LL_ENDL;
@@ -3509,10 +3509,10 @@ void LLViewerWindow::handleScrollWheel(S32 clicks)
         S32 local_x;
         S32 local_y;
         top_ctrl->screenPointToLocal( mCurrentMousePoint.mX, mCurrentMousePoint.mY, &local_x, &local_y );
-        if (top_ctrl->handleScrollWheel(local_x, local_y, clicks)) return;
+        if (top_ctrl->handleScrollWheel(local_x, local_y, delta)) return;
     }
 
-    if (mRootView->handleScrollWheel(mCurrentMousePoint.mX, mCurrentMousePoint.mY, clicks) )
+    if (mRootView->handleScrollWheel(mCurrentMousePoint.mX, mCurrentMousePoint.mY, delta) )
     {
         if (LLView::sDebugMouseHandling)
         {
@@ -3530,12 +3530,12 @@ void LLViewerWindow::handleScrollWheel(S32 clicks)
     if(top_ctrl == 0
         && getWorldViewRectScaled().pointInRect(mCurrentMousePoint.mX, mCurrentMousePoint.mY)
         && gAgentCamera.isInitialized())
-        gAgentCamera.handleScrollWheel(clicks);
+        gAgentCamera.handleScrollWheel(delta.mPrecise);
 
     return;
 }
 
-void LLViewerWindow::handleScrollHWheel(S32 clicks)
+void LLViewerWindow::handleScrollHWheel(LLScrollDelta delta)
 {
     if (LLAppViewer::instance()->quitRequested())
     {
@@ -3550,7 +3550,7 @@ void LLViewerWindow::handleScrollHWheel(S32 clicks)
         S32 local_x;
         S32 local_y;
         mouse_captor->screenPointToLocal(mCurrentMousePoint.mX, mCurrentMousePoint.mY, &local_x, &local_y);
-        mouse_captor->handleScrollHWheel(local_x, local_y, clicks);
+        mouse_captor->handleScrollHWheel(local_x, local_y, delta);
         if (LLView::sDebugMouseHandling)
         {
             LL_INFOS() << "Scroll Horizontal Wheel handled by captor " << mouse_captor->getName() << LL_ENDL;
@@ -3564,10 +3564,10 @@ void LLViewerWindow::handleScrollHWheel(S32 clicks)
         S32 local_x;
         S32 local_y;
         top_ctrl->screenPointToLocal(mCurrentMousePoint.mX, mCurrentMousePoint.mY, &local_x, &local_y);
-        if (top_ctrl->handleScrollHWheel(local_x, local_y, clicks)) return;
+        if (top_ctrl->handleScrollHWheel(local_x, local_y, delta)) return;
     }
 
-    if (mRootView->handleScrollHWheel(mCurrentMousePoint.mX, mCurrentMousePoint.mY, clicks))
+    if (mRootView->handleScrollHWheel(mCurrentMousePoint.mX, mCurrentMousePoint.mY, delta))
     {
         if (LLView::sDebugMouseHandling)
         {

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -3489,6 +3489,11 @@ void LLViewerWindow::handleScrollWheel(LLScrollDelta delta)
 {
     LLUI::getInstance()->resetMouseIdleTimer();
 
+    // Scale the precise (smooth) component by the user's sensitivity multiplier.
+    // Discrete consumers read delta.mClicks and are intentionally left untouched.
+    static LLCachedControl<F32> scroll_sensitivity(gSavedSettings, "MouseWheelScrollSensitivity", 1.f);
+    delta.mPrecise *= scroll_sensitivity;
+
     LLMouseHandler* mouse_captor = gFocusMgr.getMouseCapture();
     if( mouse_captor )
     {
@@ -3543,6 +3548,9 @@ void LLViewerWindow::handleScrollHWheel(LLScrollDelta delta)
     }
 
     LLUI::getInstance()->resetMouseIdleTimer();
+
+    static LLCachedControl<F32> scroll_sensitivity(gSavedSettings, "MouseWheelScrollSensitivity", 1.f);
+    delta.mPrecise *= scroll_sensitivity;
 
     LLMouseHandler* mouse_captor = gFocusMgr.getMouseCapture();
     if (mouse_captor)

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -3185,7 +3185,7 @@ bool LLViewerWindow::handleKey(KEY key, MASK mask)
             }
 #endif
 
-#ifdef LL_WINDOWS
+#if LL_WINDOWS && !LL_SDL_WINDOW
             // On windows Alt Gr key generates additional Ctrl event, as result handling situations
             // like 'AltGr + D' will result in 'Alt+Ctrl+D'. If it results in WM_CHAR, don't let it
             // pass into menu or it will trigger 'develop' menu assigned to this combination on top

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -2317,7 +2317,8 @@ LLViewerWindow::LLViewerWindow(const Params& p)
     // keeps it in sync on subsequent changes.
     if (gKeyboard)
     {
-        gKeyboard->setNumpadDistinct(static_cast<LLKeyboard::e_numpad_distinct>(gSavedSettings.getS32("NumpadControl")));
+        S32 numpad_mode = llclamp(gSavedSettings.getS32("NumpadControl"), (S32)LLKeyboard::ND_NEVER, (S32)LLKeyboard::ND_NUMLOCK_ON);
+        gKeyboard->setNumpadDistinct(static_cast<LLKeyboard::e_numpad_distinct>(numpad_mode));
     }
 
     mDebugText = new LLDebugText(this);

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -2310,6 +2310,16 @@ LLViewerWindow::LLViewerWindow(const Params& p)
     // Can't have spaces in settings.ini strings, so use underscores instead and convert them.
     LLStringUtil::replaceChar(mOverlayTitle, '_', ' ');
 
+    // Sync the keyboard's numpad mode with the saved NumpadControl setting now
+    // that gKeyboard exists. settings_setup_listeners() only connects the change
+    // signal (and ran before the window/keyboard were created), so push the
+    // persisted value into LLKeyboard once here; handleNumpadControlChanged
+    // keeps it in sync on subsequent changes.
+    if (gKeyboard)
+    {
+        gKeyboard->setNumpadDistinct(static_cast<LLKeyboard::e_numpad_distinct>(gSavedSettings.getS32("NumpadControl")));
+    }
+
     mDebugText = new LLDebugText(this);
 
     mWorldViewRectScaled = calcScaledRect(mWorldViewRectRaw, mDisplayScale);

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -231,8 +231,8 @@ public:
     /*virtual*/ bool handleActivateApp(LLWindow *window, bool activating);
     /*virtual*/ void handleMenuSelect(LLWindow *window,  S32 menu_item);
     /*virtual*/ bool handlePaint(LLWindow *window,  S32 x,  S32 y,  S32 width,  S32 height);
-    /*virtual*/ void handleScrollWheel(LLWindow *window,  S32 clicks);
-    /*virtual*/ void handleScrollHWheel(LLWindow *window,  S32 clicks);
+    /*virtual*/ void handleScrollWheel(LLWindow *window,  LLScrollDelta delta);
+    /*virtual*/ void handleScrollHWheel(LLWindow *window,  LLScrollDelta delta);
     /*virtual*/ bool handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask);
     /*virtual*/ void handleWindowBlock(LLWindow *window);
     /*virtual*/ void handleWindowUnblock(LLWindow *window);
@@ -352,8 +352,8 @@ public:
     LLView*         getLoginPanelHolder() { return mLoginPanelHolder.get(); }
     bool            handleKey(KEY key, MASK mask);
     bool            handleKeyUp(KEY key, MASK mask);
-    void            handleScrollWheel   (S32 clicks);
-    void            handleScrollHWheel  (S32 clicks);
+    void            handleScrollWheel   (LLScrollDelta delta);
+    void            handleScrollHWheel  (LLScrollDelta delta);
 
     // add and remove views from "popup" layer
     void            addPopup(LLView* popup);

--- a/indra/newview/llwindowlistener.cpp
+++ b/indra/newview/llwindowlistener.cpp
@@ -557,7 +557,7 @@ void LLWindowListener::mouseScroll(LLSD const & request)
 {
     S32 clicks = request["clicks"].asInteger();
 
-    mWindow->handleScrollWheel(NULL, clicks);
+    mWindow->handleScrollWheel(NULL, LLScrollDelta(clicks, (F32)clicks));
 }
 
 void LLWindowListener::pasteText(LLSD const & evt)

--- a/indra/newview/skins/default/xui/en/panel_preferences_move_general.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move_general.xml
@@ -179,6 +179,39 @@
    height="10"
    layout="topleft"
    left="86"
+   name="numpad_control_lbl"
+   width="150"
+   top_pad="20">
+    Numeric keypad:
+  </text>
+  <combo_box
+   control_name="NumpadControl"
+   height="23"
+   layout="topleft"
+   left_pad="10"
+   top_delta="-6"
+   name="numpad_control_combo"
+   width="200">
+    <combo_box.item
+     label="Acts like the arrow keys"
+     name="0"
+     value="0"/>
+    <combo_box.item
+     label="Moves me when NumLock is off"
+     name="1"
+     value="1"/>
+    <combo_box.item
+     label="Always moves me (ignore NumLock)"
+     name="2"
+     value="2"/>
+  </combo_box>
+  <text
+   follows="left|top"
+   type="string"
+   length="1"
+   height="10"
+   layout="topleft"
+   left="86"
    name="single_click_action_lbl"
    width="150"
    top_pad="20">

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -82,6 +82,8 @@ class ViewerManifest(LLManifest):
                 self.exclude("logcontrol-dev.xml")
                 self.path("*.ini")
                 self.path("*.xml")
+                # Branded splash icon for the SDL splash screen (LLSplashScreenSDL)
+                self.path("alchemy_logo.png")
 
                 # include the entire shaders directory recursively
                 self.path("shaders")

--- a/indra/vcpkg.json
+++ b/indra/vcpkg.json
@@ -127,11 +127,15 @@
     },
     {
       "name": "sdl3-image",
-      "platform": "osx",
       "features": [
-        "tiff"
+        "png",
+        {
+          "name": "tiff",
+          "platform": "osx"
+        }
       ]
     },
+    "sdl3-ttf",
     "secondlife-emoji-shortcodes",
     "simdjson",
     "simdutf",


### PR DESCRIPTION
## Summary

Brings the SDL3 window/input backend (already the default on Linux) to **Windows** as an **opt-in** alternative to the native Win32 backend, behind `USE_SDL_WINDOW` (`vs2026-os-sdl` presets). The native Win32 backend remains the default and is unchanged for normal builds.

Along the way this lands the high-precision (sub-notch) scroll-wheel work and restores distinct-numpad avatar control, both shared across all backends.

## What's included

**SDL3 window backend (Windows)**
- Unified SDL main-callbacks entry point shared with Linux/macOS; `LLAppViewerWin32` is driven through the `SDL_App*` callbacks, keeping the Win32 platform overrides (NVAPI, Velopack, crash handling, single-instance mutex, WM_COPYDATA SLURL hand-off, DirectInput8/joystick, serial number).
- Native shared GL contexts for worker threads via the platform GL API behind SDL (WGL sibling context on Windows; CGL/GLX/EGL elsewhere) instead of SDL's hidden-carrier-window pattern.
- `LLWindowSDL` splash screen (SDL_ttf + SDL_image, branded icon).
- Branded cursors loaded from the exe's embedded `.cur` resources; DXGI VRAM-budget query shared with the native backend; COM init tolerant of SDL's early COM bring-up.

**Input / scrolling (all backends)**
- High-precision floating-point scroll (`LLScrollDelta`: integer `mClicks` for discrete consumers, `mPrecise` for continuous) — smooth sub-notch scrolling/zoom for scrollbars, camera, minimap/world-map/previews and mouselook FOV; `MouseWheelScrollSensitivity` setting; momentum scrolling on macOS.
- Distinct numpad avatar/camera control restored via the `NumpadControl` setting (off / NumLock-off / always), matched across the SDL and Win32 keyboards.

**Hardening / fixes**
- Fix `gIconResource` undeclared in the default (non-SDL) Windows build.
- Sub-notch scroll no longer double-scrolls nested scroll areas; numpad press/release stays symmetric across a mid-press NumLock toggle.
- Assorted SDL backend robustness: TEXT_INPUT Ctrl-accelerator filter, empty-resolution guard, degenerate-resize floor, teardown null-window guards, splash partial-init cleanup, flash-icon guards.
- Cache window pixel density/height off the per-event input path (drops per-event `GetClientRect`).

## Platform / opt-in

- **Windows** — opt-in via `-DUSE_SDL_WINDOW=ON` (or the `vs2026-os-sdl` presets). Default builds use the native Win32 backend and are unaffected.
- **Linux / macOS** — SDL remains the default backend.

## Testing

- Default (non-SDL) Windows build compiles (verified the restored `gIconResource` path).
- SDL Windows build compiles and runs; exercised in-world during native-vs-SDL performance comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
