### PR TITLE
Fix first few chars of UUIDs missing in profiles (#299)

### DIFF
--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -212,7 +212,9 @@ LLLineEditor::LLLineEditor(const LLLineEditor::Params& p)
 
     // clamp text padding to current editor size
     updateTextPadding();
-    setCursor(mText.length());
+
+    // read-only fields anchor to start, editable ones to end of initial text
+    setCursor(mReadOnly ? 0 : mText.length());
 
     if (mSpellCheck)
     {
@@ -454,7 +456,16 @@ void LLLineEditor::setText(const LLStringExplicit &new_text, bool use_size_limit
         // try to preserve insertion point, but deselect text
         deselect();
     }
-    setCursor(llmin((S32)mText.length(), getCursor()));
+
+    if (mReadOnly)
+    {
+        // display field, anchor to start so the value isn't scrolled off
+        setCursor(0);
+    }
+    else
+    {
+        setCursor(llmin((S32)mText.length(), getCursor()));
+    }
 
     // Set current history line to end of history.
     if (mLineHistory.empty())


### PR DESCRIPTION
Works around a `LLLineEditor` quirk to fix #299.

The Key field in profiles uses a read-only `LLLineEditor` (likely so the UUID stays selectable). By default it places the cursor at the end of the text even though it's read-only, causing the first few characters of the key to get clipped out of view.

This initially anchors read-only line editors to the start of the text instead.

Other read-only line editors that should technically benefit:

- `group_key` group UUID, same issue as the profile key
- `user_name`/`display_name` long display or legacy names in profiles
- `pick_name`/`pick_location` profile picks
- `view_subject`/`view_inventory_name`/`create_inventory_name` group notices
- `edt_invname_*` region environment inventory names