### PR TITLE
Some macOS focus/input tweaks, plus a few other minor fixes

### DIFF
--- a/indra/llwindow/CMakeLists.txt
+++ b/indra/llwindow/CMakeLists.txt
@@ -68,6 +68,22 @@ if(USE_SDL_WINDOW)
 
   target_compile_definitions(llwindow PUBLIC LL_SDL_WINDOW=1)
 
+  if(DARWIN)
+    # macOS-only Objective-C++ helper that fixes up SDL's auto-created Cocoa
+    # menu bar (strips the Cmd+W shortcut off its default Window > Close item).
+    target_sources(llwindow
+      PRIVATE
+        llsdl_macos.mm
+      PUBLIC
+        llsdl_macos.h
+    )
+
+    # llwindow reuses llprecompiled's C++ PCH; that PCH has no Objective-C++
+    # variant, so skip it for the .mm or CMake fails to resolve a cmake_pch.objcxx
+    # header it expects this target to provide.
+    set_source_files_properties(llsdl_macos.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+  endif()
+
   target_link_libraries(llwindow
     ll::SDL3
   )

--- a/indra/llwindow/llsdl.cpp
+++ b/indra/llwindow/llsdl.cpp
@@ -133,6 +133,12 @@ void set_sdl_hints()
 
                     // Momentum scrolling on macos is desirable for mac touchpads
                     {SDL_HINT_MAC_SCROLL_MOMENTUM, "1"},
+
+                    // Don't let SDL post a synthetic SDL_EVENT_QUIT when the
+                    // last window closes. The viewer owns its own shutdown
+                    // sequence (LLAppViewer), and transient teardown of the
+                    // main window must never be read as a request to quit.
+                    {SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE, "0"},
             };
 
     for (auto hint: hintList)

--- a/indra/llwindow/llsdl.cpp
+++ b/indra/llwindow/llsdl.cpp
@@ -46,6 +46,10 @@ bool gSDLMainHandled = false;
 #include "llwin32headers.h" // CS_BYTEALIGNCLIENT / CS_OWNDC
 #endif
 
+#if LL_DARWIN
+#include "llsdl_macos.h"
+#endif
+
 void sdl_logger(void *userdata, int category, SDL_LogPriority priority, const char *message)
 {
     switch (priority)
@@ -206,6 +210,14 @@ void init_sdl(const std::string& app_name)
             }
         }
     }
+
+#if LL_DARWIN
+    // SDL has now registered the app and built its default Cocoa menu bar. Drop
+    // the Cmd+W shortcut off its auto-created Window > Close item so the
+    // shortcut reaches the viewer's own "Close Window" handler instead of
+    // tearing down the window (which the SDL backend reads as a quit request).
+    ll_sdl_macos_strip_default_close_shortcut();
+#endif
 }
 
 void quit_sdl()

--- a/indra/llwindow/llsdl_macos.h
+++ b/indra/llwindow/llsdl_macos.h
@@ -31,3 +31,7 @@
 // llsdl_macos.mm for the full rationale. Safe to call once after the first
 // SDL_INIT_VIDEO (when SDL has registered the app and built its menu).
 void ll_sdl_macos_strip_default_close_shortcut();
+
+// Make the given SDL window key again after a native file dialog closes.
+struct SDL_Window;
+void ll_sdl_macos_make_window_key_deferred(struct SDL_Window* window);

--- a/indra/llwindow/llsdl_macos.h
+++ b/indra/llwindow/llsdl_macos.h
@@ -1,0 +1,33 @@
+/**
+ * @file llsdl_macos.h
+ * @brief macOS-specific SDL helpers
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#pragma once
+
+// Remove the Cmd+W key equivalent from the "Close" item in the default macOS
+// menu bar that SDL3's Cocoa backend creates for us. See the implementation in
+// llsdl_macos.mm for the full rationale. Safe to call once after the first
+// SDL_INIT_VIDEO (when SDL has registered the app and built its menu).
+void ll_sdl_macos_strip_default_close_shortcut();

--- a/indra/llwindow/llsdl_macos.mm
+++ b/indra/llwindow/llsdl_macos.mm
@@ -28,6 +28,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "SDL3/SDL.h"
+
 #include "llsdl_macos.h"
 
 void ll_sdl_macos_strip_default_close_shortcut()
@@ -72,6 +74,31 @@ void ll_sdl_macos_strip_default_close_shortcut()
             }
         }
     }
+}
+
+void ll_sdl_macos_make_window_key_deferred(struct SDL_Window* window)
+{
+    if (!window)
+    {
+        return;
+    }
+
+    NSWindow* ns_window = (__bridge NSWindow*)SDL_GetPointerProperty(
+        SDL_GetWindowProperties(window), SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+    if (!ns_window)
+    {
+        return;
+    }
+
+    // After a native dialog closes, SDL only reactivates the app, leaving no
+    // key window: keystrokes hit no responder and AppKit beeps. Re-key the
+    // window so it becomes key again and SDL emits FOCUS_GAINED, restoring input.
+    // Defer to the next main-queue turn so this runs after SDL's own
+    // ReactivateAfterDialog instead of being clobbered by it.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [NSApp activateIgnoringOtherApps:YES];
+        [ns_window makeKeyAndOrderFront:nil];
+    });
 }
 
 #endif // LL_DARWIN

--- a/indra/llwindow/llsdl_macos.mm
+++ b/indra/llwindow/llsdl_macos.mm
@@ -1,0 +1,77 @@
+/**
+ * @file llsdl_macos.mm
+ * @brief macOS-specific SDL helpers
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifdef LL_DARWIN
+
+#import <Cocoa/Cocoa.h>
+
+#include "llsdl_macos.h"
+
+void ll_sdl_macos_strip_default_close_shortcut()
+{
+    @autoreleasepool
+    {
+        // SDL3's Cocoa backend auto-creates a default menu bar (it does this
+        // whenever [NSApp mainMenu] is nil at registration) whose "Window"
+        // menu contains a "Close" item bound to Cmd+W via -performClose:. That
+        // native item swallows Cmd+W before it can reach the viewer's own
+        // in-window "Close Window" accelerator (menu_viewer.xml -> control|W ->
+        // File.CloseWindow, which just closes the frontmost floater). Worse,
+        // -performClose: on the sole viewer window triggers
+        // SDL_EVENT_WINDOW_CLOSE_REQUESTED, which LLWindowSDL turns into a full
+        // application quit. Clear the key equivalent so Cmd+W falls through to
+        // LLMenuGL instead of quitting the viewer. The menu item itself stays
+        // (still clickable); only its keyboard shortcut is removed.
+        // SDL parks "Close" in the menu it hands to -setWindowsMenu:, but scan
+        // every top-level submenu rather than assuming that location, so this
+        // keeps working if SDL ever rearranges its default bar.
+        NSMenu* main_menu = [NSApp mainMenu];
+        if (!main_menu)
+        {
+            return;
+        }
+
+        for (NSMenuItem* top_item in [main_menu itemArray])
+        {
+            NSMenu* submenu = [top_item submenu];
+            if (!submenu)
+            {
+                continue;
+            }
+
+            for (NSMenuItem* item in [submenu itemArray])
+            {
+                if ([item action] == @selector(performClose:))
+                {
+                    [item setKeyEquivalent:@""];
+                    [item setKeyEquivalentModifierMask:0];
+                }
+            }
+        }
+    }
+}
+
+#endif // LL_DARWIN

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -69,6 +69,7 @@ LLWindowSDL::WAYLAND_DATA LLWindowSDL::sWaylandData = {};
 #include <CoreServices/CoreServices.h>
 #include <CoreGraphics/CGDisplayConfiguration.h>
 #include <SDL3_image/SDL_image.h>
+#include "llsdl_macos.h"
 
 bool LLWindowSDL::sUseMultGL = false;
 #endif
@@ -1752,6 +1753,26 @@ LLWindow::LLWindowResolution* LLWindowSDL::getSupportedResolutions(S32 &num_reso
 SDL_Window* LLWindowSDL::getMainSDLWindow()
 {
     return gWindowImplementation ? gWindowImplementation->mWindow : nullptr;
+}
+
+//static
+void LLWindowSDL::restoreFocusAfterDialog()
+{
+    if (!gWindowImplementation || !gWindowImplementation->mWindow)
+    {
+        return;
+    }
+
+#if LL_DARWIN
+    // SDL's macOS dialog leaves us with no key window on close; see llsdl_macos.mm.
+    ll_sdl_macos_make_window_key_deferred(gWindowImplementation->mWindow);
+#else
+    SDL_RaiseWindow(gWindowImplementation->mWindow);
+    if (gWindowImplementation->mCallbacks)
+    {
+        gWindowImplementation->mCallbacks->handleFocus(gWindowImplementation);
+    }
+#endif
 }
 
 //static

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -1756,23 +1756,48 @@ SDL_Window* LLWindowSDL::getMainSDLWindow()
 }
 
 //static
-void LLWindowSDL::restoreFocusAfterDialog()
+void LLWindowSDL::enterDialog()
 {
-    if (!gWindowImplementation || !gWindowImplementation->mWindow)
+    if (gWindowImplementation)
+    {
+        gWindowImplementation->beforeDialog();
+    }
+}
+
+//static
+void LLWindowSDL::exitDialog()
+{
+    LLWindowSDL* self = gWindowImplementation;
+    if (!self)
     {
         return;
     }
 
-#if LL_DARWIN
-    // SDL's macOS dialog leaves us with no key window on close; see llsdl_macos.mm.
-    ll_sdl_macos_make_window_key_deferred(gWindowImplementation->mWindow);
-#else
-    SDL_RaiseWindow(gWindowImplementation->mWindow);
-    if (gWindowImplementation->mCallbacks)
+    self->afterDialog();
+
+    if (self->mDialogDepth != 0 || !self->mWindow)
     {
-        gWindowImplementation->mCallbacks->handleFocus(gWindowImplementation);
+        return;
+    }
+
+    // afterDialog() restores fullscreen and mouselook; the file dialog also needs
+    // key-window focus back once the last one closes. SDL's dialog sheet leaves no
+    // key window, so without this keystrokes hit no responder and AppKit beeps.
+#if LL_DARWIN
+    ll_sdl_macos_make_window_key_deferred(self->mWindow);
+#else
+    SDL_RaiseWindow(self->mWindow);
+    if (self->mCallbacks)
+    {
+        self->mCallbacks->handleFocus(self);
     }
 #endif
+}
+
+//static
+bool LLWindowSDL::dialogOpen()
+{
+    return gWindowImplementation && gWindowImplementation->mDialogDepth > 0;
 }
 
 //static

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -214,8 +214,17 @@ public:
     // worker thread has its own GL context current.
     static SDL_Window* getMainSDLWindow();
 
-    // Re-focus the main window after a native file dialog closes.
-    static void restoreFocusAfterDialog();
+    // Bracket an async OS dialog. SDL3's file picker resolves on a later frame,
+    // so beforeDialog()/afterDialog() can't wrap it on a single stack frame;
+    // enterDialog()/exitDialog() drive the same mDialogDepth machinery from the
+    // launch site and the completion callback instead. exitDialog() also restores
+    // key-window focus, which SDL leaves dropped after its dialog sheet closes.
+    static void enterDialog();
+    static void exitDialog();
+
+    // True while any OS dialog is up. The frame loop services modeless pickers,
+    // so it must skip BackgroundYieldTime while one is open or it turns laggy.
+    static bool dialogOpen();
 
 #if LL_DARWIN
     static U64 getVramSize();

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -214,6 +214,9 @@ public:
     // worker thread has its own GL context current.
     static SDL_Window* getMainSDLWindow();
 
+    // Re-focus the main window after a native file dialog closes.
+    static void restoreFocusAfterDialog();
+
 #if LL_DARWIN
     static U64 getVramSize();
     static void setUseMultGL(bool use_mult_gl);

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -154,7 +154,6 @@
 
 #if LL_SDL_WINDOW
 #include "llwindowsdl.h"
-#include "llsdlfiledialog.h"
 #endif
 
 // Third party library includes
@@ -1563,7 +1562,7 @@ bool LLAppViewer::doFrame()
             // don't background-yield while one is open or it turns laggy.
             bool native_dialog_open = false;
 #if LL_SDL_WINDOW
-            native_dialog_open = LLSDLFileDialog::anyOpen();
+            native_dialog_open = LLWindowSDL::dialogOpen();
 #endif
 
             // yield cooperatively when not running as foreground window

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -154,6 +154,7 @@
 
 #if LL_SDL_WINDOW
 #include "llwindowsdl.h"
+#include "llsdlfiledialog.h"
 #endif
 
 // Third party library includes
@@ -1558,9 +1559,17 @@ bool LLAppViewer::doFrame()
                 ms_sleep(non_interactive_ms_sleep_time);
             }
 
+            // A native picker steals key focus but is serviced by this loop, so
+            // don't background-yield while one is open or it turns laggy.
+            bool native_dialog_open = false;
+#if LL_SDL_WINDOW
+            native_dialog_open = LLSDLFileDialog::anyOpen();
+#endif
+
             // yield cooperatively when not running as foreground window
             // and when not quiting (causes trouble at mac's cleanup stage)
             if (!LLApp::isExiting()
+                && !native_dialog_open
                 && ((gViewerWindow && !gViewerWindow->getWindow()->getVisible())
                     || !gFocusMgr.getAppHasFocus()))
             {

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -693,6 +693,7 @@ void LLNetMap::reshape(S32 width, S32 height, bool called_from_parent)
 {
     LLUICtrl::reshape(width, height, called_from_parent);
     createObjectImage();
+    createParcelImage();
 }
 
 LLVector3 LLNetMap::globalPosToView(const LLVector3d& global_pos)

--- a/indra/newview/llsdlfiledialog.h
+++ b/indra/newview/llsdlfiledialog.h
@@ -32,6 +32,7 @@
 #include "SDL3/SDL.h"
 #include "llwindowsdl.h"
 
+#include <atomic>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -74,6 +75,18 @@ struct LLSDLFileDialogContext
 
 namespace LLSDLFileDialog
 {
+    // Count of async dialogs on screen, so the frame loop can skip
+    // BackgroundYieldTime while a picker holds focus (the modeless dialog is
+    // serviced by the same loop, so yielding makes it laggy). Atomic: launched
+    // from a worker thread, resolved on the main thread.
+    inline std::atomic<int>& openDialogCount()
+    {
+        static std::atomic<int> sCount{0};
+        return sCount;
+    }
+
+    inline bool anyOpen() { return openDialogCount().load(std::memory_order_relaxed) > 0; }
+
     // C-style trampoline matching SDL_DialogFileCallback. Decodes the
     // filelist into ResultT, invokes the user's typed callback, and
     // frees the heap-allocated context. ResultT-specialised below for
@@ -81,6 +94,9 @@ namespace LLSDLFileDialog
     template <typename ResultT>
     inline void trampoline(void* userdata, const char* const* filelist, int /*filter*/)
     {
+        // Dialog resolved; release the hold taken in show().
+        openDialogCount().fetch_sub(1, std::memory_order_relaxed);
+
         auto* ctx = static_cast<LLSDLFileDialogContext<ResultT>*>(userdata);
         auto* cb = ctx->mCallback;
         auto* user = ctx->mUserdata;
@@ -146,6 +162,9 @@ namespace LLSDLFileDialog
         {
             SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, location.c_str());
         }
+
+        // Held until trampoline() runs; see openDialogCount().
+        openDialogCount().fetch_add(1, std::memory_order_relaxed);
 
         SDL_ShowFileDialogWithProperties(type, &trampoline<ResultT>, ctx, props);
 

--- a/indra/newview/llsdlfiledialog.h
+++ b/indra/newview/llsdlfiledialog.h
@@ -32,7 +32,6 @@
 #include "SDL3/SDL.h"
 #include "llwindowsdl.h"
 
-#include <atomic>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -75,18 +74,6 @@ struct LLSDLFileDialogContext
 
 namespace LLSDLFileDialog
 {
-    // Count of async dialogs on screen, so the frame loop can skip
-    // BackgroundYieldTime while a picker holds focus (the modeless dialog is
-    // serviced by the same loop, so yielding makes it laggy). Atomic: launched
-    // from a worker thread, resolved on the main thread.
-    inline std::atomic<int>& openDialogCount()
-    {
-        static std::atomic<int> sCount{0};
-        return sCount;
-    }
-
-    inline bool anyOpen() { return openDialogCount().load(std::memory_order_relaxed) > 0; }
-
     // C-style trampoline matching SDL_DialogFileCallback. Decodes the
     // filelist into ResultT, invokes the user's typed callback, and
     // frees the heap-allocated context. ResultT-specialised below for
@@ -94,14 +81,9 @@ namespace LLSDLFileDialog
     template <typename ResultT>
     inline void trampoline(void* userdata, const char* const* filelist, int /*filter*/)
     {
-        // Dialog resolved; release the hold taken in show().
-        openDialogCount().fetch_sub(1, std::memory_order_relaxed);
-
-        // Restore viewer focus once the last dialog closes.
-        if (openDialogCount().load(std::memory_order_relaxed) == 0)
-        {
-            LLWindowSDL::restoreFocusAfterDialog();
-        }
+        // Dialog resolved; close the bracket opened in show(). Restores
+        // fullscreen/mouselook and, once the last dialog closes, key focus.
+        LLWindowSDL::exitDialog();
 
         auto* ctx = static_cast<LLSDLFileDialogContext<ResultT>*>(userdata);
         auto* cb = ctx->mCallback;
@@ -169,8 +151,9 @@ namespace LLSDLFileDialog
             SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, location.c_str());
         }
 
-        // Held until trampoline() runs; see openDialogCount().
-        openDialogCount().fetch_add(1, std::memory_order_relaxed);
+        // Open the dialog bracket; trampoline() closes it. Drops fullscreen and
+        // mouselook for the dialog's duration, like the blocking pickers do.
+        LLWindowSDL::enterDialog();
 
         SDL_ShowFileDialogWithProperties(type, &trampoline<ResultT>, ctx, props);
 

--- a/indra/newview/llsdlfiledialog.h
+++ b/indra/newview/llsdlfiledialog.h
@@ -97,6 +97,12 @@ namespace LLSDLFileDialog
         // Dialog resolved; release the hold taken in show().
         openDialogCount().fetch_sub(1, std::memory_order_relaxed);
 
+        // Restore viewer focus once the last dialog closes.
+        if (openDialogCount().load(std::memory_order_relaxed) == 0)
+        {
+            LLWindowSDL::restoreFocusAfterDialog();
+        }
+
         auto* ctx = static_cast<LLSDLFileDialogContext<ResultT>*>(userdata);
         auto* cb = ctx->mCallback;
         auto* user = ctx->mUserdata;

--- a/indra/newview/llsdlfiledialog.h
+++ b/indra/newview/llsdlfiledialog.h
@@ -81,9 +81,10 @@ namespace LLSDLFileDialog
     template <typename ResultT>
     inline void trampoline(void* userdata, const char* const* filelist, int /*filter*/)
     {
-        // Dialog resolved; close the bracket opened in show(). Restores
-        // fullscreen/mouselook and, once the last dialog closes, key focus.
-        LLWindowSDL::exitDialog();
+        // Close the bracket opened in show(), on the main thread: the callback can
+        // fire on a worker thread (the Linux Zenity backend), and exitDialog()
+        // touches mDialogDepth and window focus. Runs inline when already on main.
+        SDL_RunOnMainThread([](void*) { LLWindowSDL::exitDialog(); }, nullptr, false);
 
         auto* ctx = static_cast<LLSDLFileDialogContext<ResultT>*>(userdata);
         auto* cb = ctx->mCallback;

--- a/indra/newview/skins/default/xui/en/panel_preferences_general.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_general.xml
@@ -208,7 +208,7 @@
      width="18"/>
      <check_box
        control_name="ShowFavoritesOnLogin"
-       enabled="false" 
+       enabled="false"
        height="16"
        layout="topleft"
        label="Show favorite locations on login screen"
@@ -245,23 +245,23 @@
      height="20"
      layout="topleft"
      left="35"
-     top_pad="5" 
+     top_pad="5"
      name="Name_Tag_Preference">
         <radio_item
          label="Off"
          name="radio"
-         top_delta="20" 
+         top_delta="20"
          layout="topleft"
-         height="16" 
-         left="0" 
+         height="16"
+         left="0"
          value="0"
          width="75" />
         <radio_item
          label="On"
          left_pad="0"
          layout="topleft"
-         top_delta="0" 
-         height="16" 
+         top_delta="0"
+         height="16"
          name="radio2"
          value="1"
          width="75" />
@@ -294,6 +294,16 @@
      left_pad="50"
      name="show_slids"
      tool_tip="Show username, like bobsmith123"
+     top_delta="0" />
+   <check_box
+     control_name="NameTagShowDistance"
+	 enabled_control="AvatarNameTagMode"
+     height="16"
+     label="Distance"
+     layout="topleft"
+     left_pad="50"
+     name="show_distance"
+     tool_tip="Show distance in meters on name tags"
      top_delta="0" />
     <check_box
      control_name="UseDisplayNames"
@@ -350,32 +360,32 @@
        Pressing letter keys:
    </text>
    <radio_group
-     control_name="LetterKeysFocusChatBar" 
+     control_name="LetterKeysFocusChatBar"
      height="34"
      layout="topleft"
      left="35"
-     top_pad="5" 
+     top_pad="5"
      name="inworld_typing_preference">
         <radio_item
          label="Starts local chat"
          name="radio_start_chat"
-         top="0" 
+         top="0"
          layout="topleft"
-         height="16" 
-         left="0" 
+         height="16"
+         left="0"
          value="1"
          width="150" />
         <radio_item
          label="Affects movement (i.e. WASD)"
          left="0"
          layout="topleft"
-         top="18" 
-         height="16" 
+         top="18"
+         height="16"
          name="radio_move"
          value="0"
          width="75" />
     </radio_group>
-    
+
     <text
      type="string"
      length="1"
@@ -384,7 +394,7 @@
      layout="topleft"
      left="30"
      name="title_afk_text"
-     top_pad="5" 
+     top_pad="5"
      width="190">
     	Away timeout:
     </text>

--- a/indra/newview/skins/default/xui/en/panel_tools_texture.xml
+++ b/indra/newview/skins/default/xui/en/panel_tools_texture.xml
@@ -31,7 +31,7 @@
             <button
              follows="top|left"
              layout="topleft"
-             height="19" 
+             height="19"
              left="258"
              tab_stop="false"
              image_overlay="Clipboard_Copy"
@@ -57,7 +57,7 @@
              mouse_opaque="true"
              tab_stop="false"
              image_selected="eye_button_active.tga"
-             image_unselected="eye_button_inactive.tga" 
+             image_unselected="eye_button_inactive.tga"
              name="pipette_color_btn"
              tool_tip="Paste Color Parameters using the Pipette tool"
              width="20" />
@@ -204,15 +204,15 @@
                 <radio_item
                 label="Texture (diffuse)"
                 name="Texture (diffuse)"
-                top="0" 
+                top="0"
                 layout="topleft"
-                height="16" 
+                height="16"
                 value="0"/>
                 <radio_item
                 label="Bumpiness (normal)"
                 layout="topleft"
-                top_pad="1" 
-                height="16" 
+                top_pad="1"
+                height="16"
                 name="Bumpiness (normal)"
                 value="1"/>
                 <radio_item
@@ -242,8 +242,8 @@
                 label="Base color"
                 name="Base color"
                 layout="topleft"
-                top_pad="1" 
-                height="16" 
+                top_pad="1"
+                height="16"
                 value="1"/>
                 <radio_item
                 label="Metallic/roughness"
@@ -256,21 +256,21 @@
                 label="Emissive"
                 name="Emissive"
                 layout="topleft"
-                top_pad="1" 
-                height="16" 
+                top_pad="1"
+                height="16"
                 value="3"/>
                 <radio_item
                 label="Normal"
                 layout="topleft"
-                top_pad="1" 
-                height="16" 
+                top_pad="1"
+                height="16"
                 name="Normal"
                 value="4"/>
             </radio_group>
             <button
              follows="top|left"
              layout="topleft"
-             height="19" 
+             height="19"
              left="258"
              top_delta="0"
              tab_stop="false"
@@ -297,7 +297,7 @@
              mouse_opaque="true"
              tab_stop="false"
              image_selected="eye_button_active.tga"
-             image_unselected="eye_button_inactive.tga" 
+             image_unselected="eye_button_inactive.tga"
              name="pipette_texture_btn"
              tool_tip="Paste Texture Parameters using the Pipette tool"
              width="20" />
@@ -320,7 +320,7 @@
              height="23"
              layout="topleft"
              left_pad="10"
-             top_delta="10"
+             top_delta="22"
              name="pbr_from_inventory"
              label="Choose from inventory"
              width="140"/>
@@ -369,7 +369,7 @@
              left="10"
              name="texture control"
              tool_tip="Click to choose a picture"
-             top_delta="-64"
+             top_delta="-76"
              width="64" />
             <text
             visible="false"
@@ -748,7 +748,7 @@
              left="10"
              name="tex gen"
              text_readonly_color="LabelDisabledColor"
-             top_pad="51"
+             top_pad="56"
              width="196">
                 Mapping
             </text>


### PR DESCRIPTION
Several quick adjustments, thought it'd be better to bundle these. Let me know if you'd prefer any pulled out, or changed.

**macOS focus/input related**

- Stop ⌘+W from calling quit
- Avoid background-yield while a native file dialog is open
  - Somehow it was making the upload dialog laggy, just disabled it while an upload modal is open at the moment, this might be a fair bit on the hacky side?
- Restore window focus after a native file dialog closes

**Plus few minor fixes**

- Add a show-distance toggle for name tag options
- Some overlapping in tools
- Mini-map parcel boundaries scaling to 2x sim size on resize

---

<img width="416" height="154" alt="SCR-20260627-jiky" src="https://github.com/user-attachments/assets/639d89af-683f-4a00-937d-ad5b75e69692" />

Show distance toggle for name tags

<img width="339" height="501" alt="SCR-20260627-jihm" src="https://github.com/user-attachments/assets/a71ddd3b-8c46-49bb-9dde-6141cf4cd52c" />

Normal radio input no longer partially obscured by the "choose from/save to inventory" button