### PR TITLE
Add group chat snooze menu back from history

### DIFF
--- a/indra/newview/llfloaterimsession.cpp
+++ b/indra/newview/llfloaterimsession.cpp
@@ -66,7 +66,7 @@
 #include "llfloatergroupinvite.h"
 #include "llgroupactions.h"
 #include "llslurl.h"
-#include <boost/lexical_cast.hpp>
+#include "llstring.h"
 // [/SL:KB]
 // [RLVa:KB] - Checked: 2013-05-10 (RLVa-1.4.9)
 #include "rlvactions.h"
@@ -285,19 +285,21 @@ void LLFloaterIMSession::onSnoozeGroupClicked(const LLUICtrl* pCtrl)
         return;
     }
 
-    const std::string value = pCtrl->getValue().asString();
-    if (value == "-1")
+    const std::string snooze_value = pCtrl->getValue().asString();
+    S32 snooze_duration = 0;
+    if (!snooze_value.empty())
     {
-        LLGroupActions::leaveIM(mSessionID);
+        S32 snooze_minutes = 0;
+        if (!LLStringUtil::convertToS32(snooze_value, snooze_minutes))
+        {
+            LL_WARNS("IMVIEW") << "Invalid group IM snooze value: " << snooze_value << LL_ENDL;
+            return;
+        }
+
+        snooze_duration = snooze_minutes < 0 ? -1 : snooze_minutes * 60;
     }
-    else if (value.empty())
-    {
-        LLGroupActions::snoozeIM(mSessionID, 0);
-    }
-    else
-    {
-        LLGroupActions::snoozeIM(mSessionID, boost::lexical_cast<S32>(value) * 60);
-    }
+
+    LLGroupActions::snoozeIM(mSessionID, snooze_duration);
 }
 
 void LLFloaterIMSession::onTeleportClicked(const LLUICtrl* pCtrl)
@@ -500,7 +502,7 @@ bool LLFloaterIMSession::postBuild()
         mExtendedButtonPanel->getChild<LLUICtrl>("profile_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::GearDoToSelectedGroup, this, "view_profile"));
         mExtendedButtonPanel->getChild<LLUICtrl>("chat_history_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::GearDoToSelectedGroup, this, "chat_history"));
         mExtendedButtonPanel->getChild<LLUICtrl>("view_notices_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::GearDoToSelectedGroup, this, "view_notices"));
-        mExtendedButtonPanel->getChild<LLUICtrl>("snooze_groupt_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::onSnoozeGroupClicked, this, _1));
+        mExtendedButtonPanel->getChild<LLUICtrl>("snooze_group_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::onSnoozeGroupClicked, this, _1));
     }
 // [/SL:KB]
 

--- a/indra/newview/llfloaterimsession.cpp
+++ b/indra/newview/llfloaterimsession.cpp
@@ -278,6 +278,28 @@ void LLFloaterIMSession::GearDoToSelectedGroup(const LLSD& userdata)
 // [/SL:KB]
 
 // [SL:KB] - Patch: Chat-Misc | Checked: 2014-03-22 (Catznip-3.6)
+void LLFloaterIMSession::onSnoozeGroupClicked(const LLUICtrl* pCtrl)
+{
+    if (!pCtrl)
+    {
+        return;
+    }
+
+    const std::string value = pCtrl->getValue().asString();
+    if (value == "-1")
+    {
+        LLGroupActions::leaveIM(mSessionID);
+    }
+    else if (value.empty())
+    {
+        LLGroupActions::snoozeIM(mSessionID, 0);
+    }
+    else
+    {
+        LLGroupActions::snoozeIM(mSessionID, boost::lexical_cast<S32>(value) * 60);
+    }
+}
+
 void LLFloaterIMSession::onTeleportClicked(const LLUICtrl* pCtrl)
 {
     if (pCtrl)
@@ -478,6 +500,7 @@ bool LLFloaterIMSession::postBuild()
         mExtendedButtonPanel->getChild<LLUICtrl>("profile_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::GearDoToSelectedGroup, this, "view_profile"));
         mExtendedButtonPanel->getChild<LLUICtrl>("chat_history_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::GearDoToSelectedGroup, this, "chat_history"));
         mExtendedButtonPanel->getChild<LLUICtrl>("view_notices_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::GearDoToSelectedGroup, this, "view_notices"));
+        mExtendedButtonPanel->getChild<LLUICtrl>("snooze_groupt_btn")->setCommitCallback(boost::bind(&LLFloaterIMSession::onSnoozeGroupClicked, this, _1));
     }
 // [/SL:KB]
 

--- a/indra/newview/llfloaterimsession.h
+++ b/indra/newview/llfloaterimsession.h
@@ -112,6 +112,7 @@ public:
     bool checkGearMenuItem(const LLSD& userdata);
 // [SL:KB] - Patch: Chat-Misc | Checked: 2014-03-22 (Catznip-3.6)
     void onTeleportClicked(const LLUICtrl* pCtrl);
+    void onSnoozeGroupClicked(const LLUICtrl* pCtrl);
 // [/SL:KB]
 // [SL:KB] - Patch: Chat-BaseGearBtn | Checked: 2014-04-10 (Catznip-3.6)
     void GearDoToSelectedGroup(const LLSD& userdata);

--- a/indra/newview/llgroupactions.cpp
+++ b/indra/newview/llgroupactions.cpp
@@ -605,6 +605,27 @@ LLUUID LLGroupActions::startIM(const LLUUID& group_id)
     }
 }
 
+static void close_group_im(const LLUUID& group_id, LLIMModel::LLIMSession::SCloseAction close_action, S32 snooze_duration = -1)
+{
+    if (group_id.isNull())
+    {
+        return;
+    }
+
+    LLUUID session_id = gIMMgr->computeSessionID(IM_SESSION_GROUP_START, group_id);
+    if (session_id.notNull())
+    {
+        LLIMModel::LLIMSession* session = LLIMModel::getInstance()->findIMSession(session_id);
+        if (session)
+        {
+            session->mCloseAction = close_action;
+            session->mSnoozeDuration = snooze_duration;
+        }
+
+        gIMMgr->leaveSession(session_id);
+    }
+}
+
 // static
 void LLGroupActions::endIM(const LLUUID& group_id)
 {
@@ -616,6 +637,18 @@ void LLGroupActions::endIM(const LLUUID& group_id)
     {
         gIMMgr->leaveSession(session_id);
     }
+}
+
+// static
+void LLGroupActions::leaveIM(const LLUUID& group_id)
+{
+    close_group_im(group_id, LLIMModel::LLIMSession::SCloseAction::CLOSE_LEAVE);
+}
+
+// static
+void LLGroupActions::snoozeIM(const LLUUID& group_id, S32 snooze_duration)
+{
+    close_group_im(group_id, LLIMModel::LLIMSession::SCloseAction::CLOSE_SNOOZE, snooze_duration);
 }
 
 // static

--- a/indra/newview/llgroupactions.h
+++ b/indra/newview/llgroupactions.h
@@ -105,6 +105,8 @@ public:
      * End group instant messaging session.
      */
     static void endIM(const LLUUID& group_id);
+    static void leaveIM(const LLUUID& group_id);
+    static void snoozeIM(const LLUUID& group_id, S32 snooze_duration = -1);
 
     /// Returns if the current user is a member of the group
     static bool isInGroup(const LLUUID& group_id);

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -1353,7 +1353,7 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                 }
             }
 
-            else if (offline == IM_ONLINE && is_do_not_disturb)
+            if (offline == IM_ONLINE && is_do_not_disturb)
             {
 
                 // return a standard "do not disturb" message, but only do it to online IM

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -1345,7 +1345,12 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
             // should happen after you get an "invitation"
             if (!gIMMgr->hasSession(session_id))
             {
-                return;
+                if (!gAgent.isInGroup(session_id) ||
+                    !gIMMgr->checkSnoozeExpiration(session_id) ||
+                    !gIMMgr->restoreSnoozedSession(session_id))
+                {
+                    return;
+                }
             }
 
             else if (offline == IM_ONLINE && is_do_not_disturb)

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3558,8 +3558,8 @@ bool LLIMMgr::leaveSession(const LLUUID& session_id)
 
     if (im_session->isGroupSessionType() && im_session->mCloseAction == LLIMModel::LLIMSession::SCloseAction::CLOSE_SNOOZE)
     {
-        const F64 duration = llmax(0, im_session->mSnoozeDuration);
-        mSnoozedSessions[session_id] = LLTimer::getTotalSeconds() + duration;
+        const S32 duration = im_session->mSnoozeDuration;
+        mSnoozedSessions[session_id] = duration < 0 ? -1.0 : LLTimer::getTotalSeconds() + duration;
     }
     else
     {
@@ -3760,7 +3760,7 @@ bool LLIMMgr::hasSession(const LLUUID& session_id)
 bool LLIMMgr::checkSnoozeExpiration(const LLUUID& session_id) const
 {
     snoozed_sessions_t::const_iterator it = mSnoozedSessions.find(session_id);
-    return it != mSnoozedSessions.end() && it->second <= LLTimer::getTotalSeconds();
+    return it != mSnoozedSessions.end() && it->second >= 0.0 && it->second <= LLTimer::getTotalSeconds();
 }
 
 bool LLIMMgr::isSnoozedSession(const LLUUID& session_id) const
@@ -3776,13 +3776,13 @@ bool LLIMMgr::restoreSnoozedSession(const LLUUID& session_id)
         return false;
     }
 
-    mSnoozedSessions.erase(it);
-
     LLGroupData group_data;
     if (!gAgent.getGroupData(session_id, group_data))
     {
         return false;
     }
+
+    mSnoozedSessions.erase(it);
 
     gIMMgr->addSession(group_data.mName, IM_SESSION_GROUP_START, session_id);
 

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3559,7 +3559,8 @@ bool LLIMMgr::leaveSession(const LLUUID& session_id)
     if (im_session->isGroupSessionType() && im_session->mCloseAction == LLIMModel::LLIMSession::SCloseAction::CLOSE_SNOOZE)
     {
         const S32 duration = im_session->mSnoozeDuration;
-        mSnoozedSessions[session_id] = duration < 0 ? -1.0 : LLTimer::getTotalSeconds() + duration;
+        const F64 now = LLTimer::getTotalSeconds();
+        mSnoozedSessions[session_id] = duration < 0 ? -1.0 : now + duration;
     }
     else
     {

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3556,7 +3556,17 @@ bool LLIMMgr::leaveSession(const LLUUID& session_id)
     LLIMModel::LLIMSession* im_session = LLIMModel::getInstance()->findIMSession(session_id);
     if (!im_session) return false;
 
-    LLIMModel::getInstance()->sendLeaveSession(session_id, im_session->mOtherParticipantID);
+    if (im_session->isGroupSessionType() && im_session->mCloseAction == LLIMModel::LLIMSession::SCloseAction::CLOSE_SNOOZE)
+    {
+        const F64 duration = llmax(0, im_session->mSnoozeDuration);
+        mSnoozedSessions[session_id] = LLTimer::getTotalSeconds() + duration;
+    }
+    else
+    {
+        LLIMModel::getInstance()->sendLeaveSession(session_id, im_session->mOtherParticipantID);
+        mSnoozedSessions.erase(session_id);
+    }
+
     gIMMgr->removeSession(session_id);
     return true;
 }
@@ -3745,6 +3755,45 @@ void LLIMMgr::disconnectAllSessions()
 bool LLIMMgr::hasSession(const LLUUID& session_id)
 {
     return LLIMModel::getInstance()->findIMSession(session_id) != NULL;
+}
+
+bool LLIMMgr::checkSnoozeExpiration(const LLUUID& session_id) const
+{
+    snoozed_sessions_t::const_iterator it = mSnoozedSessions.find(session_id);
+    return it != mSnoozedSessions.end() && it->second <= LLTimer::getTotalSeconds();
+}
+
+bool LLIMMgr::isSnoozedSession(const LLUUID& session_id) const
+{
+    return mSnoozedSessions.find(session_id) != mSnoozedSessions.end();
+}
+
+bool LLIMMgr::restoreSnoozedSession(const LLUUID& session_id)
+{
+    snoozed_sessions_t::iterator it = mSnoozedSessions.find(session_id);
+    if (it == mSnoozedSessions.end())
+    {
+        return false;
+    }
+
+    mSnoozedSessions.erase(it);
+
+    LLGroupData group_data;
+    if (!gAgent.getGroupData(session_id, group_data))
+    {
+        return false;
+    }
+
+    gIMMgr->addSession(group_data.mName, IM_SESSION_GROUP_START, session_id);
+
+    uuid_vec_t ids;
+    LLIMModel::sendStartSession(session_id, session_id, ids, IM_SESSION_GROUP_START, false);
+
+    if (!gAgent.isDoNotDisturb())
+    {
+        make_ui_sound("UISndStartIM");
+    }
+    return true;
 }
 
 void LLIMMgr::clearPendingInvitation(const LLUUID& session_id)
@@ -4441,4 +4490,3 @@ LLHTTPRegistration<LLViewerChatterBoxSessionUpdate>
 LLHTTPRegistration<LLViewerChatterBoxInvitation>
     gHTTPRegistrationMessageChatterBoxInvitation(
         "/message/ChatterBoxInvitation");
-

--- a/indra/newview/llimview.h
+++ b/indra/newview/llimview.h
@@ -79,6 +79,13 @@ public:
             NONE_SESSION,
         } SType;
 
+        enum class SCloseAction
+        {
+            CLOSE_DEFAULT,
+            CLOSE_LEAVE,
+            CLOSE_SNOOZE
+        };
+
         LLIMSession(const LLUUID& session_id, const std::string& name,
             const EInstantMessage& type, const LLUUID& other_participant_id, const LLSD& voiceChannelInfo, const uuid_vec_t& ids, bool has_offline_msg);
         virtual ~LLIMSession();
@@ -122,6 +129,8 @@ public:
         std::string mName;
         EInstantMessage mType;
         SType mSessionType;
+        SCloseAction mCloseAction = SCloseAction::CLOSE_DEFAULT;
+        S32 mSnoozeDuration = -1;
         LLUUID mOtherParticipantID;
         uuid_vec_t mInitialTargetIDs;
         std::string mHistoryFileName;
@@ -444,6 +453,9 @@ public:
     void disconnectAllSessions();
 
     bool hasSession(const LLUUID& session_id);
+    bool checkSnoozeExpiration(const LLUUID& session_id) const;
+    bool isSnoozedSession(const LLUUID& session_id) const;
+    bool restoreSnoozedSession(const LLUUID& session_id);
 
     static LLUUID computeSessionID(EInstantMessage dialog, const LLUUID& other_participant_id);
 
@@ -529,6 +541,9 @@ private:
 
     LLSD mPendingInvitations;
     LLSD mPendingAgentListUpdates;
+
+    typedef std::map<LLUUID, F64> snoozed_sessions_t;
+    snoozed_sessions_t mSnoozedSessions;
 };
 
 class LLCallDialogManager : public LLSingleton<LLCallDialogManager>

--- a/indra/newview/skins/default/xui/en/floater_im_session.xml
+++ b/indra/newview/skins/default/xui/en/floater_im_session.xml
@@ -309,7 +309,7 @@
                    label=""
                    layout="topleft"
                    left_pad="2"
-                   name="snooze_groupt_btn"
+                   name="snooze_group_btn"
                    tool_tip="Snooze group chat"
                    top="1"
                    width="44">

--- a/indra/newview/skins/default/xui/en/floater_im_session.xml
+++ b/indra/newview/skins/default/xui/en/floater_im_session.xml
@@ -301,6 +301,56 @@
                    tool_tip="View group notices"
                    top="1"
                    width="31" />
+                  <flyout_button
+                   arrow_button_width="18"
+                   follows="top|left"
+                   height="25"
+                   halign="left"
+                   label=""
+                   layout="topleft"
+                   left_pad="2"
+                   name="snooze_groupt_btn"
+                   tool_tip="Snooze group chat"
+                   top="1"
+                   width="44">
+                    <flyout_button.item
+                     label="Next message"
+                     value="0" />
+                    <flyout_button.item
+                     label="5 minutes"
+                     value="5" />
+                    <flyout_button.item
+                     label="15 minutes"
+                     value="15" />
+                    <flyout_button.item
+                     label="30 minutes"
+                     value="30" />
+                    <flyout_button.item
+                     label="45 minutes"
+                     value="45" />
+                    <flyout_button.item
+                     label="1 hour"
+                     value="60" />
+                    <flyout_button.item
+                     label="Next relog"
+                     value="-1" />
+                    <flyout_button.action_button
+                     image_bottom_pad="1"
+                     image_hover_unselected="Toolbar_Middle_Over"
+                     image_overlay="Conv_toolbar_snooze"
+                     image_overlay_alignment="left"
+                     image_selected="Toolbar_Middle_Selected"
+                     image_unselected="transparent.j2c"
+                     imgoverlay_label_space="0" />
+                    <flyout_button.drop_down_button
+                     image_hover_unselected="Toolbar_Middle_Over"
+                     image_overlay="Arrow_Small_Down"
+                     image_overlay_alignment="right"
+                     image_pressed="none"
+                     image_selected="Toolbar_Middle_Selected"
+                     image_unselected="Toolbar_Middle_Off"
+                     pad_right="-2" />
+                  </flyout_button>
                 </panel>           
                 <button
                  follows="right|top"


### PR DESCRIPTION
## Description

Adds the group chat snooze flyout/menu back to group IM sessions on `develop`.

This restores the small group chat toolbar menu that allows a group conversation to be snoozed for:

- Next message
- 5 minutes
- 15 minutes
- 30 minutes
- 45 minutes
- 1 hour
- Next relog

The implementation ports the group-chat floater/action/session pieces from the older `main` history into the current `develop` IM/session code. It tracks snoozed group sessions locally, suppresses reopening while the snooze is active, and restores the group session when a message arrives after the snooze expires.

<img width="1041" height="508" alt="image" src="https://github.com/user-attachments/assets/a92170e6-3462-45da-981e-20d463ca9846" />

Historical attribution/context:

- Based primarily on old `main` commit `be67f0cd6c06` by @RyeMutt: “Port Catznip's snooze group feature”.
- That commit itself credits Catznip as the original source of the group snooze feature.
- This branch builds on group muting work already present on `develop`, including `2c15baf8b5` by @cinderblocks/@RyeMutt , originally from Katherine Berry, and follow-up `ced1e6ed9b` by Rye for muted group chat session behavior.
- I intentionally did not restore the older group profile/options behavior around snoozing on close, because later old-`main` commits `f804d2e7f80d` / `821bc5b960fe` by @RyeMutt partially backed out/adjusted that area. This PR is scoped to the explicit group chat toolbar snooze menu.

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

Local verification completed:

```powershell
.\.venv\Scripts\Activate.ps1
cmake --build build-Windows-vs2026-os --config Release