### PR TITLE
Fix uncommon CTD in llsidepanelappearance.cpp

### DIFF
--- a/indra/newview/llsidepanelappearance.cpp
+++ b/indra/newview/llsidepanelappearance.cpp
@@ -50,6 +50,7 @@
 #include "llviewerregion.h"
 #include "llvoavatarself.h"
 #include "llviewerwearable.h"
+#include "llappviewer.h"
 
 static LLPanelInjector<LLSidepanelAppearance> t_appearance("sidepanel_appearance");
 
@@ -457,6 +458,24 @@ void LLSidepanelAppearance::toggleWearableEditPanel(bool visible, LLViewerWearab
 }
 
 void LLSidepanelAppearance::refreshCurrentOutfitName(const std::string& name)
+{
+    // May be invoked from a background coroutine (e.g. an AIS inventory
+    // update). Text layout here can rasterize new glyphs / create GL
+    // textures, which is only safe on the main coroutine, so hop there.
+    LLHandle<LLPanel> handle = getHandle();
+    std::string name_copy = name;
+    LLAppViewer::instance()->postToMainCoro(
+        [handle, name_copy]()
+        {
+            LLSidepanelAppearance* self = dynamic_cast<LLSidepanelAppearance*>(handle.get());
+            if (self)
+            {
+                self->refreshCurrentOutfitNameImpl(name_copy);
+            }
+        });
+}
+
+void LLSidepanelAppearance::refreshCurrentOutfitNameImpl(const std::string& name)
 {
     // Set current outfit status (wearing/unsaved).
     bool dirty = LLAppearanceMgr::getInstance()->isOutfitDirty();

--- a/indra/newview/llsidepanelappearance.h
+++ b/indra/newview/llsidepanelappearance.h
@@ -80,7 +80,7 @@ public:
 private:
     void onFilterEdit(const std::string& search_string);
     void onVisibilityChanged ( const LLSD& new_visibility );
-    
+
     void refreshCurrentOutfitNameImpl(const std::string& name);
 
     void onOpenOutfitButtonClicked();

--- a/indra/newview/llsidepanelappearance.h
+++ b/indra/newview/llsidepanelappearance.h
@@ -80,6 +80,8 @@ public:
 private:
     void onFilterEdit(const std::string& search_string);
     void onVisibilityChanged ( const LLSD& new_visibility );
+    
+    void refreshCurrentOutfitNameImpl(const std::string& name);
 
     void onOpenOutfitButtonClicked();
     void onEditAppearanceButtonClicked();


### PR DESCRIPTION
## Description

Fixes a rare CTD which is triggered by the UI update on the appearance panel being pushed through an unsafe part, causing a crash relating to text rendering.

This PR amends the path to use the safe path as seen in many other functions in the codebase.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
