### PR TITLE
Fix: bind Alt+Shift+X to toggle DoF focus lock (RenderFocusPointLocked)

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -2431,6 +2431,24 @@ function="World.EnvPreset"
              function="ToggleControl"
              parameter="DisableCameraConstraints" />
         </menu_item_check>
+        <!-- Lock the Depth-of-Field focus point in place. Registers the
+             Alt+Shift+X accelerator advertised by the "Lock Focus (alt+shift+X)"
+             checkbox in the Lightbox (graphics) floater; both drive the same
+             RenderFocusPointLocked setting, which is read by
+             LLPipeline::renderDoF(). Kept always-enabled (no enabled_control)
+             so the shortcut fires regardless of whether the Advanced menu is
+             visible or Depth of Field is currently on. -->
+        <menu_item_check
+         label="Lock DoF Focus Point"
+         name="Lock DoF Focus Point"
+         shortcut="alt|shift|X">
+            <menu_item_check.on_check
+             function="CheckControl"
+             parameter="RenderFocusPointLocked" />
+            <menu_item_check.on_click
+             function="ToggleControl"
+             parameter="RenderFocusPointLocked" />
+        </menu_item_check>
 
         <menu_item_separator/>
 		<menu_item_check


### PR DESCRIPTION
## Summary

The **Lock Focus** checkbox in the Lightbox settings floater advertises a keyboard shortcut in its own label — `label="Lock Focus (alt+shift+X)"` — but **no accelerator was ever bound to `RenderFocusPointLocked`**. Pressing <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> did nothing; the shortcut was advertised but never wired (or lost in a merge). This PR wires it up.

## Root cause

- `RenderFocusPointLocked` (`settings_alchemy.xml`) is read by `LLPipeline::renderDoF()` to freeze the Depth-of-Field focus point. The feature itself works via the Lightbox checkbox.
- Repo-wide, `alt|shift|X` had **zero** bindings. The only `…|X` accelerator was `control|alt|shift|X` (Ctrl+Alt+Shift+X) for the unrelated *Inventory Thumbnails Helper*.
- No command referenced the DoF lock by shortcut — the `LockFocus`/`FocusLocked` symbols elsewhere in the tree all belong to the unrelated follow-camera system.

## Change

A single `menu_item_check` added to the **Advanced** menu in `indra/newview/skins/default/xui/en/menu_viewer.xml`, beside the existing camera toggles, using the menu's standard `ToggleControl`/`CheckControl` handlers:

```xml
<menu_item_check label="Lock DoF Focus Point" name="Lock DoF Focus Point" shortcut="alt|shift|X">
    <menu_item_check.on_check function="CheckControl"  parameter="RenderFocusPointLocked" />
    <menu_item_check.on_click function="ToggleControl" parameter="RenderFocusPointLocked" />
</menu_item_check>
```

### Design notes
- **Fires even when the Advanced menu is hidden.** `LLMenuGL::handleAcceleratorKey` passes the key down to enabled-but-invisible menus (*"Pass down even if not visible"*), and the Advanced menu is gated by `setItemVisible` (visibility), not by being disabled. The accelerator is therefore global, matching the floater's promise.
- **Intentionally always-enabled** (no `enabled_control="RenderDepthOfField"`, unlike the floater checkbox). Gating it would make the shortcut silently do nothing while DoF is off — reproducing the original "shortcut is broken" report. Toggling the lock while DoF is off is harmless.
- **English-only edit is sufficient.** The per-language `menu_viewer.xml` files are overlay diffs that fall back to the `en` node, so the item appears in every locale (English label until translated).

## Testing
- XML well-formedness validated; the new `name` is unique; `alt|shift|X` is now the single accelerator match repo-wide.
- **Runtime smoke test:** staged build launched to the login screen (OpenGL 4.6 core) with **zero** XUI/menu/accelerator warnings in the log — menu bar and accelerator registered cleanly.
- **Manual:** <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> toggles the DoF focus lock in-viewer (reflected on the Lightbox "Lock Focus" checkbox), including with the Advanced menu hidden. ✅

## Risk
Data-only XUI change; no C++ modified. Scope is one menu item plus its accelerator.

## Follow-up (optional)
Happy to add a lightweight regression-guard test asserting this menu item / accelerator wiring exists, to keep an advertised-but-unbound state from recurring in a future merge — let me know if that's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
