### PR TITLE
Fix another outfit-related CTD

### DIFF
--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -1683,7 +1683,11 @@ void AISUpdate::doUpdate()
         // fetching can receive massive amount of items and folders
         if (gInventory.getChangedIDs().size() > MAX_UPDATE_BACKLOG)
         {
-            gInventory.notifyObservers();
+            LLAppViewer::instance()->postToMainCoro(
+                []()
+                {
+                    gInventory.notifyObservers();
+                });
             checkTimeout();
         }
     }
@@ -1744,7 +1748,11 @@ void AISUpdate::doUpdate()
         // fetching can receive massive amount of items and folders
         if (gInventory.getChangedIDs().size() > MAX_UPDATE_BACKLOG)
         {
-            gInventory.notifyObservers();
+            LLAppViewer::instance()->postToMainCoro(
+                []()
+                {
+                    gInventory.notifyObservers();
+                });
             checkTimeout();
         }
     }
@@ -1815,6 +1823,10 @@ void AISUpdate::doUpdate()
 
     checkTimeout();
 
-    gInventory.notifyObservers();
+    LLAppViewer::instance()->postToMainCoro(
+        []()
+        {
+            gInventory.notifyObservers();
+        });
 }
 

--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -1044,6 +1044,13 @@ void AISAPI::InvokeAISCommandCoro(LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t ht
 U32 AISUpdate::sBatchFrameCount = 0;
 LLTimer AISUpdate::sBatchTimer;
 
+// Coalesces the deferred gInventory::notifyObservers() calls issued below
+// when the change backlog exceeds MAX_UPDATE_BACKLOG, so repeated iterations
+// while the backlog remains large don't flood gMainloopWork with duplicate
+// postToMainCoro callbacks. Cleared once the posted callback actually runs
+// notifyObservers().
+static bool sAISNotifyObserversPending = false;
+
 AISUpdate::AISUpdate(const LLSD& update, AISAPI::COMMAND_TYPE type, const LLSD& request_body)
 : mType(type)
 {
@@ -1683,11 +1690,16 @@ void AISUpdate::doUpdate()
         // fetching can receive massive amount of items and folders
         if (gInventory.getChangedIDs().size() > MAX_UPDATE_BACKLOG)
         {
-            LLAppViewer::instance()->postToMainCoro(
-                []()
-                {
-                    gInventory.notifyObservers();
-                });
+            if (!sAISNotifyObserversPending)
+            {
+                sAISNotifyObserversPending = true;
+                LLAppViewer::instance()->postToMainCoro(
+                    []()
+                    {
+                        gInventory.notifyObservers();
+                        sAISNotifyObserversPending = false;
+                    });
+            }
             checkTimeout();
         }
     }
@@ -1748,11 +1760,16 @@ void AISUpdate::doUpdate()
         // fetching can receive massive amount of items and folders
         if (gInventory.getChangedIDs().size() > MAX_UPDATE_BACKLOG)
         {
-            LLAppViewer::instance()->postToMainCoro(
-                []()
-                {
-                    gInventory.notifyObservers();
-                });
+            if (!sAISNotifyObserversPending)
+            {
+                sAISNotifyObserversPending = true;
+                LLAppViewer::instance()->postToMainCoro(
+                    []()
+                    {
+                        gInventory.notifyObservers();
+                        sAISNotifyObserversPending = false;
+                    });
+            }
             checkTimeout();
         }
     }
@@ -1829,4 +1846,3 @@ void AISUpdate::doUpdate()
             gInventory.notifyObservers();
         });
 }
-

--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -1051,6 +1051,20 @@ LLTimer AISUpdate::sBatchTimer;
 // notifyObservers().
 static bool sAISNotifyObserversPending = false;
 
+static void aisScheduleNotifyObservers()
+{
+    if (!sAISNotifyObserversPending)
+    {
+        sAISNotifyObserversPending = true;
+        LLAppViewer::instance()->postToMainCoro(
+            []()
+            {
+                gInventory.notifyObservers();
+                sAISNotifyObserversPending = false;
+            });
+    }
+}
+
 AISUpdate::AISUpdate(const LLSD& update, AISAPI::COMMAND_TYPE type, const LLSD& request_body)
 : mType(type)
 {
@@ -1690,16 +1704,7 @@ void AISUpdate::doUpdate()
         // fetching can receive massive amount of items and folders
         if (gInventory.getChangedIDs().size() > MAX_UPDATE_BACKLOG)
         {
-            if (!sAISNotifyObserversPending)
-            {
-                sAISNotifyObserversPending = true;
-                LLAppViewer::instance()->postToMainCoro(
-                    []()
-                    {
-                        gInventory.notifyObservers();
-                        sAISNotifyObserversPending = false;
-                    });
-            }
+            aisScheduleNotifyObservers();
             checkTimeout();
         }
     }
@@ -1760,16 +1765,7 @@ void AISUpdate::doUpdate()
         // fetching can receive massive amount of items and folders
         if (gInventory.getChangedIDs().size() > MAX_UPDATE_BACKLOG)
         {
-            if (!sAISNotifyObserversPending)
-            {
-                sAISNotifyObserversPending = true;
-                LLAppViewer::instance()->postToMainCoro(
-                    []()
-                    {
-                        gInventory.notifyObservers();
-                        sAISNotifyObserversPending = false;
-                    });
-            }
+            aisScheduleNotifyObservers();
             checkTimeout();
         }
     }
@@ -1840,9 +1836,12 @@ void AISUpdate::doUpdate()
 
     checkTimeout();
 
-    LLAppViewer::instance()->postToMainCoro(
-        []()
-        {
-            gInventory.notifyObservers();
-        });
+    if (!sAISNotifyObserversPending)
+    {
+        LLAppViewer::instance()->postToMainCoro(
+            []()
+            {
+                gInventory.notifyObservers();
+            });
+    }
 }

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -2174,7 +2174,10 @@ void LLInventoryModel::deleteObject(const LLUUID& id, bool fix_broken_links, boo
 
     // Note : We need to tell the inventory observers that those things are going to be deleted *before* the tree is cleared or they won't know what to delete (in views and view models)
     addChangedMask(LLInventoryObserver::REMOVE, id);
-    gInventory.notifyObservers();
+    if (do_notify_observers)
+    {
+        notifyObservers();
+    }
 
     if (item_array_t* item_list = getUnlockedItemArray(id))
     {


### PR DESCRIPTION
## Description

Defers notifying observers to run on the main thread. This fixes a CTD wherein glyph creation could happen outside of the main thread which would cause a CTD if uncaught.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
