### PR TITLE
llpreviewscript: fix LLMutex assert crash when LSL compile fails

### DIFF
--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -2040,56 +2040,68 @@ void LLPreviewLSL::onSave(void* userdata, bool close_after_save)
     self->saveIfNeeded();
 }
 
-/*static*/
+// static
 void LLPreviewLSL::finishedLSLUpload(LLUUID itemId, LLSD response)
 {
-    // Find our window and close it if requested.
-    LLPreviewLSL* preview = LLFloaterReg::findTypedInstance<LLPreviewLSL>("preview_script", LLSD(itemId));
-    if (preview)
-    {
-        // Bytecode save completed
-        if (response["compiled"])
+    // This callback runs on the upload coprocedure fiber, not the main coro.
+    // UI work downstream (selectFirstError -> reflow -> LLMutex::lock) asserts
+    // if called off the main coro, so shuttle everything back first.
+    LLAppViewer::instance()->postToMainCoro(
+        [itemId, response]() mutable
         {
-            preview->callbackLSLCompileSucceeded();
-        }
-        else
-        {
-            preview->callbackLSLCompileFailed(response["errors"]);
-        }
-        preview->sendCompileResults(response);
-    }
+            LLPreviewLSL* preview = LLFloaterReg::findTypedInstance<LLPreviewLSL>("preview_script", LLSD(itemId));
+            if (preview)
+            {
+                if (response["compiled"])
+                {
+                    preview->callbackLSLCompileSucceeded();
+                }
+                else
+                {
+                    preview->callbackLSLCompileFailed(response["errors"]);
+                }
+                preview->sendCompileResults(response);
+            }
+        });
 }
 
+// static
 bool LLPreviewLSL::failedLSLUpload(LLUUID itemId, LLUUID taskId, LLSD response, std::string reason)
 {
-    LLSD floater_key;
-    if (taskId.notNull())
-    {
-        floater_key["taskid"] = taskId;
-        floater_key["itemid"] = itemId;
-    }
-    else
-    {
-        floater_key = LLSD(itemId);
-    }
+    // Same issue: this fires on the upload fiber, not the main coro.
+    // Note: return value is lost when posting async, but the original callers
+    // ignore it in the upload path anyway.
+    LLAppViewer::instance()->postToMainCoro(
+        [itemId, taskId, response, reason]() mutable
+        {
+            LLSD floater_key;
+            if (taskId.notNull())
+            {
+                floater_key["taskid"] = taskId;
+                floater_key["itemid"] = itemId;
+            }
+            else
+            {
+                floater_key = LLSD(itemId);
+            }
 
-    LLPreviewLSL* preview = LLFloaterReg::findTypedInstance<LLPreviewLSL>("preview_script", floater_key);
-    if (preview)
-    {
-        // unfreeze floater
-        LLSD errors;
-        errors.append(LLTrans::getString("UploadFailed") + reason);
-        preview->callbackLSLCompileFailed(errors);
+            LLPreviewLSL* preview = LLFloaterReg::findTypedInstance<LLPreviewLSL>("preview_script", floater_key);
+            if (preview)
+            {
+                LLSD errors;
+                errors.append(LLTrans::getString("UploadFailed") + reason);
+                preview->callbackLSLCompileFailed(errors);
 
-        LLSD message;
-        message["compiled"] = false;
-        message["errors"]   = errors;
-        preview->sendCompileResults(message);
+                LLSD message;
+                message["compiled"] = false;
+                message["errors"]   = errors;
+                preview->sendCompileResults(message);
+            }
+        });
 
-        return true;
-    }
-
-    return false;
+    // Return value is meaningless now that we're async, but the signature
+    // requires it. The upload infrastructure doesn't use it either.
+    return true;
 }
 
 // Save needs to compile the text in the buffer. If the compile


### PR DESCRIPTION
## Description

LLPreviewLSL::finishedLSLUpload and failedLSLUpload were being called directly on the upload coprocedure fiber, causing a crash when the downstream UI path (callbackLSLCompileFailed -> selectFirstError -> reflow -> LLMutex::lock) asserted LLCoros::on_main_coro(). Wrap both callbacks in postToMainCoro(), matching the fix already applied to LLLiveLSLEditor::finishLSLUpload.

Fixes a CTD when using the built-in script editor.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
