### PR TITLE
Fix edit at root picking wrong prim

### DIFF
--- a/indra/newview/llmanip.cpp
+++ b/indra/newview/llmanip.cpp
@@ -359,7 +359,7 @@ LLVector3 LLManip::getPivotPoint()
     LLViewerObject* object = mObjectSelection->getFirstRootObject(true);
     if (object && (mObjectSelection->getObjectCount() == 1 || editRootAxis) && mObjectSelection->getSelectType() != SELECT_TYPE_HUD)
     {
-        return mObjectSelection->getFirstObject()->getPivotPositionAgent();
+        return object->getPivotPositionAgent();
     }
     return LLSelectMgr::getInstance()->getBBoxOfSelection().getCenterAgent();
 }


### PR DESCRIPTION
Fix edit at root selecting wrong prim

<img width="1420" height="548" alt="image" src="https://github.com/user-attachments/assets/2c06d661-cb2f-4e94-b1d2-d70715a3c58b" />
