### PR TITLE
Fix double-free CTD in mesh decomp queue

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -2578,7 +2578,7 @@ EMeshProcessingResult LLMeshRepoThread::physicsShapeReceived(const LLUUID& mesh_
     LL_PROFILE_ZONE_SCOPED;
     LLSD physics_shape;
 
-    LLModel::Decomposition* d = new LLModel::Decomposition();
+    auto d = std::make_unique<LLModel::Decomposition>();
     d->mMeshID = mesh_id;
 
     if (data == NULL)
@@ -4926,8 +4926,9 @@ void LLMeshRepository::notifyDecompositionReceived(std::unique_ptr<LLModel::Deco
     decomposition_map::iterator iter = mDecompositionMap.find(decomp_id);
     if (iter == mDecompositionMap.end())
     { //just insert decomp into map
+        mDecompositionMap[decomp_id] = decomp.get();
         sCacheBytesDecomps += decomp->sizeBytes();
-        mDecompositionMap[decomp_id] = decomp.release();
+        decomp.release();
     }
     else
     { //merge decomp with existing entry

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -1014,17 +1014,6 @@ LLMeshRepoThread::~LLMeshRepoThread()
         mSkinInfoQ.pop_front();
     }
 
-    while (!mDecompositionQ.empty())
-    {
-        delete mDecompositionQ.front();
-        mDecompositionQ.pop_front();
-    }
-
-    while (!mPhysicsQ.empty())
-    {
-        delete mPhysicsQ.front();
-        mPhysicsQ.pop_front();
-    }
 
     delete mHttpRequest;
     mHttpRequest = nullptr;
@@ -2573,11 +2562,11 @@ bool LLMeshRepoThread::decompositionReceived(const LLUUID& mesh_id, U8* data, S3
     }
 
     {
-        LLModel::Decomposition* d = new LLModel::Decomposition(decomp);
+        auto d = std::make_unique<LLModel::Decomposition>(decomp);
         d->mMeshID = mesh_id;
         {
             LLMutexLock lock(mLoadedMutex);
-            mDecompositionQ.push_back(d);
+            mDecompositionQ.push_back(std::move(d));
         }
     }
 
@@ -2627,7 +2616,7 @@ EMeshProcessingResult LLMeshRepoThread::physicsShapeReceived(const LLUUID& mesh_
 
     {
         LLMutexLock lock(mLoadedMutex);
-        mPhysicsQ.push_back(d);
+        mPhysicsQ.push_back(std::move(d));
     }
     return MESH_OK;
 }
@@ -3422,8 +3411,8 @@ void LLMeshRepoThread::notifyLoadedMeshes()
     std::deque<LODRequest> unavail_queue;
     std::deque<LLPointer<LLMeshSkinInfo>> skin_info_q;
     std::deque<UUIDBasedRequest> skin_info_unavail_q;
-    std::list<LLModel::Decomposition*> decomp_q;
-    std::list<LLModel::Decomposition*> physics_q;
+    std::list<std::unique_ptr<LLModel::Decomposition>> decomp_q;
+    std::list<std::unique_ptr<LLModel::Decomposition>> physics_q;
 
     // Claim everything in one acquisition. Every producer holds mLoadedMutex only long
     // enough to push, so blocking here is cheap -- and unlike the trylock this replaces,
@@ -3525,13 +3514,13 @@ void LLMeshRepoThread::notifyLoadedMeshes()
 
         while (! decomp_q.empty())
         {
-            gMeshRepo.notifyDecompositionReceived(decomp_q.front(), false);
+            gMeshRepo.notifyDecompositionReceived(std::move(decomp_q.front()), false);
             decomp_q.pop_front();
         }
 
         while (!physics_q.empty())
         {
-            gMeshRepo.notifyDecompositionReceived(physics_q.front(), true);
+            gMeshRepo.notifyDecompositionReceived(std::move(physics_q.front()), true);
             physics_q.pop_front();
         }
     }
@@ -4931,21 +4920,20 @@ void LLMeshRepository::notifySkinInfoUnavailable(const LLUUID& mesh_id)
     }
 }
 
-void LLMeshRepository::notifyDecompositionReceived(LLModel::Decomposition* decomp, bool physics_mesh)
+void LLMeshRepository::notifyDecompositionReceived(std::unique_ptr<LLModel::Decomposition> decomp, bool physics_mesh)
 {
-    LLUUID decomp_id = decomp->mMeshID; // Copy to avoid invalidation in below deletion
+    LLUUID decomp_id = decomp->mMeshID;
     decomposition_map::iterator iter = mDecompositionMap.find(decomp_id);
     if (iter == mDecompositionMap.end())
     { //just insert decomp into map
-        mDecompositionMap[decomp_id] = decomp;
         sCacheBytesDecomps += decomp->sizeBytes();
+        mDecompositionMap[decomp_id] = decomp.release();
     }
     else
     { //merge decomp with existing entry
         sCacheBytesDecomps -= iter->second->sizeBytes();
-        iter->second->merge(decomp);
+        iter->second->merge(decomp.get());
         sCacheBytesDecomps += iter->second->sizeBytes();
-        delete decomp;
     }
 
     if (physics_mesh)

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -607,10 +607,10 @@ public:
     std::set<UUIDBasedRequest> mPhysicsShapeRequests;
 
     // list of completed Decomposition info requests
-    std::list<LLModel::Decomposition*> mDecompositionQ;
+    std::list<std::unique_ptr<LLModel::Decomposition>> mDecompositionQ;
 
     // list of completed Physics Mesh info requests
-    std::list<LLModel::Decomposition*> mPhysicsQ;
+    std::list<std::unique_ptr<LLModel::Decomposition>> mPhysicsQ;
 
     //queue of requested headers
     std::queue<HeaderRequest> mHeaderReqQ;
@@ -972,7 +972,7 @@ public:
     void notifyMeshUnavailable(const LLVolumeParams& mesh_params, S32 request_lod, S32 volume_lod);
     void notifySkinInfoReceived(LLMeshSkinInfo* info);
     void notifySkinInfoUnavailable(const LLUUID& info);
-    void notifyDecompositionReceived(LLModel::Decomposition* info, bool physics_mesh);
+    void notifyDecompositionReceived(std::unique_ptr<LLModel::Decomposition> info, bool physics_mesh);
 
     S32 getActualMeshLOD(const LLVolumeParams& mesh_params, S32 lod);
     // Non-const: memoises a "no usable LOD" verdict into header.m404.


### PR DESCRIPTION
## Description

LLModel::Decomposition objects were allocated with new and pushed onto mDecompositionQ/mPhysicsQ as raw pointers. notifyDecompositionReceived conditionally deleted the incoming pointer in the merge branch, while the LLMeshRepoThread destructor also deleted whatever remained in the queues. This made ownership impossible to reason about statically and created a double-free under certain shutdown/retry timing.

Replace the raw pointer queues with std::unique_ptr throughout:
- mDecompositionQ and mPhysicsQ now hold unique_ptr
- Local swap targets decomp_q and physics_q updated to match
- notifyDecompositionReceived takes unique_ptr by value; insert branch uses release() to transfer ownership into mDecompositionMap, merge branch uses get() and lets the unique_ptr destruct automatically
- Destructor drain loops for both queues removed as now unnecessary

mDecompositionMap retains raw pointers intentionally: getDecomposition() hands out non-owning pointers to callers and the map is a long-lived cache, not a queue. Only the queues needed ownership semantics.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
