### PR TITLE
Fix high-resolution snapshots silently falling back to tiled capture

### DIFF
--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5559,8 +5559,8 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
             // to-be-expected one.
             if (scale_factor > 1.f)
             {
-                LL_WARNS("Snapshot") << "Single-Pass snapshot at " << image_width << "x" << image_height
-                                     << " ran out of memory, using Tiled Mode." << LL_ENDL;
+                LL_WARNS("Snapshot") << "Single-pass snapshot at " << image_width << "x" << image_height
+                                     << " is unavailable; using tiled mode." << LL_ENDL;
             }
         }
     }

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5547,6 +5547,21 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
             snapshot_width  = (S32)(ratio * image_width) ;
             snapshot_height = (S32)(ratio * image_height) ;
             scale_factor = llmax(1.0f, 1.0f / ratio) ;
+
+            // Above 1 the capture is tiled, and display() -- with the whole post chain behind
+            // it -- runs once per window-sized tile. Every screen-space effect is then computed
+            // against a tile rather than the frame and restarts at the seams, which looks like a
+            // rendering fault rather than the capacity decision it is. The single-pass path
+            // declines silently, so say so here.
+            //
+            // scale_factor cannot exceed 1 with the UI shown: image_width/height were clamped to
+            // the window above, which is what makes this a fallback notice rather than a
+            // to-be-expected one.
+            if (scale_factor > 1.f)
+            {
+                LL_WARNS("Snapshot") << "Single-Pass snapshot at " << image_width << "x" << image_height
+                                     << " ran out of memory, using Tiled Mode." << LL_ENDL;
+            }
         }
     }
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5487,11 +5487,38 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
         if ((image_width <= gGLManager.mGLMaxTextureSize && image_height <= gGLManager.mGLMaxTextureSize) &&
             (image_width > window_width || image_height > window_height) && LLPipeline::sRenderDeferred && !show_ui)
         {
-            U32 color_fmt = (type == LLSnapshotModel::SNAPSHOT_TYPE_DEPTH || type == LLSnapshotModel::SNAPSHOT_TYPE_DEPTH24) ? GL_DEPTH_COMPONENT : GL_RGBA;
-            if (scratch_space.allocate(image_width, image_height, color_fmt, true))
+            // GL_RGBA8, not GL_RGBA, and not GL_DEPTH_COMPONENT for the depth layers.
+            //
+            // Storage is immutable, so this format reaches glTexStorage2D, which only accepts
+            // sized ones -- an unsized format comes back GL_INVALID_ENUM and the target fails to
+            // allocate. That failure is silent here: the block below is simply skipped, the
+            // screen buffers are never widened to the requested size, and the snapshot drops to
+            // the tiled path underneath, where the whole post chain runs once per window-sized
+            // tile. Bloom, chromatic aberration, vignette and DoF are then computed against a
+            // tile rather than the frame, which is visible as each effect restarting at the tile
+            // seams past the first.
+            //
+            // The depth layers ask for depth through the `true` below, which allocates the real
+            // (sized) depth attachment that the GL_DEPTH_COMPONENT readback further down reads.
+            // This is the colour attachment, and it needs a colour format whatever the layer is.
+            if (scratch_space.allocate(image_width, image_height, GL_RGBA8, true))
             {
-                original_width = gPipeline.mRT->deferredScreen.getWidth();
-                original_height = gPipeline.mRT->deferredScreen.getHeight();
+                // mRT->width/height, not the attachment's dimensions. allocateScreenBuffer
+                // takes a LOGICAL size, records it in mRT->width/height, and only then applies
+                // RenderResolutionDivisor / RenderResolutionMultiplier to arrive at the texture
+                // size. Reading the texture size back and handing it in as a logical size
+                // therefore applies the scale a second time, squaring it: at multiplier 2.0 the
+                // viewer comes back from a snapshot rendering four times the pixels, sixteen
+                // after the second, and at divisor 2 it halves away instead.
+                //
+                // Nothing corrects it afterwards either. resizeScreenTexture() would notice,
+                // but it is gated on gResizeScreenTexture, and the restore below assigns
+                // mWorldViewRectRaw directly rather than going through updateWorldViewRect(),
+                // which is what sets that flag. The wrong size survives until a window resize.
+                //
+                // resizeShadowTexture() already reads these two for the same reason.
+                original_width = (S32)gPipeline.mRT->width;
+                original_height = (S32)gPipeline.mRT->height;
 
                 if (gPipeline.allocateScreenBuffer(image_width, image_height))
                 {
@@ -5806,12 +5833,17 @@ bool LLViewerWindow::simpleSnapshot(LLImageRaw* raw, S32 image_width, S32 image_
 
     LLRect window_rect = getWorldViewRectRaw();
 
-    S32 original_width = LLPipeline::sRenderDeferred ? gPipeline.mRT->deferredScreen.getWidth() : gViewerWindow->getWorldViewWidthRaw();
-    S32 original_height = LLPipeline::sRenderDeferred ? gPipeline.mRT->deferredScreen.getHeight() : gViewerWindow->getWorldViewHeightRaw();
+    // The logical size, not the attachment's -- see rawSnapshot for why handing a scaled
+    // texture size back to allocateScreenBuffer squares the resolution scale.
+    S32 original_width = LLPipeline::sRenderDeferred ? (S32)gPipeline.mRT->width : gViewerWindow->getWorldViewWidthRaw();
+    S32 original_height = LLPipeline::sRenderDeferred ? (S32)gPipeline.mRT->height : gViewerWindow->getWorldViewHeightRaw();
 
     LLRenderTarget scratch_space;
-    U32 color_fmt = GL_RGBA;
-    if (scratch_space.allocate(image_width, image_height, color_fmt, true))
+    // Sized format, for the reason spelled out in rawSnapshot: immutable storage means
+    // glTexStorage2D sees this, and it rejects unsized formats. There is no tiled fallback on
+    // this path -- a failure here means the screen buffers are never resized and the readback
+    // below pulls image_width x image_height out of window-sized ones.
+    if (scratch_space.allocate(image_width, image_height, GL_RGBA8, true))
     {
         if (gPipeline.allocateScreenBuffer(image_width, image_height))
         {


### PR DESCRIPTION
## The problem

A high-resolution snapshot has a single-pass path: allocate a scratch target at the requested
size, resize the screen buffers to match, render the frame once. When that path is unavailable
the capture falls back to tiling, where `display()` runs once per window-sized tile — and drags
the whole post chain along with it.

That fallback is currently taken every time. Both snapshot scratch targets ask for `GL_RGBA`,
and `rawSnapshot`'s asks for `GL_DEPTH_COMPONENT` on the depth layers. Since 392129c034
("Allocate every LLImageGL texture with immutable storage") the format reaches `glTexStorage2D`,
which takes only sized formats and rejects the rest with `GL_INVALID_ENUM` — as
`isSizedInternalFormat` in `llimagegl.cpp` spells out. The target fails to allocate, and
`rawSnapshot` reads that as "no room for a single-pass capture".

The result is that bloom, chromatic aberration, vignette, film grain and depth of field are each
computed against a tile rather than the frame, so every full-screen effect restarts at the seams
past the first window's worth of pixels. Chromatic aberration is the plainest, being radial about
each tile's centre rather than the image's. Nothing said so beyond a one-shot format warning and
"Could not allocate color buffer for render target".

## Changes

**Sized formats at both scratch targets.** `GL_RGBA` becomes `GL_RGBA8` in `rawSnapshot` and
`simpleSnapshot`. `simpleSnapshot` has no tiled path to fall back on, so a failure there left the
screen buffers unresized and the readback pulling `image_width x image_height` out of window-sized
ones.

**The depth branch is removed rather than converted.** `GL_DEPTH_COMPONENT` was being handed to
`addColorAttachment` as a colour format, which put a depth-format texture on `GL_COLOR_ATTACHMENT0`
and never made a complete FBO even before storage went immutable. The attachment those readbacks
want is the one the `true` argument allocates, and it is sized already. This means the depth layer
types get the single-pass path too.

**The restore round trip.** Both functions saved the size to restore afterwards by reading the
deferred screen's attachment dimensions. `allocateScreenBuffer` takes a *logical* size, records it
in `mRT->width/height`, and only then applies `RenderResolutionDivisor` / `RenderResolutionMultiplier`
to reach the texture size — so feeding the texture size back in applies the scale twice. At
multiplier 2.0 the viewer returns from a snapshot rendering four times the pixels, sixteen after
the second; at divisor 2 it halves away instead. Nothing corrects it either: `resizeScreenTexture()`
would, but it is gated on `gResizeScreenTexture`, and the restore assigns `mWorldViewRectRaw`
directly rather than going through `updateWorldViewRect()`, which is what sets that flag. Both now
read `mRT->width/height`, as `resizeShadowTexture()` already does.

This one is independent of the format bug — it predates the immutable-storage change and bites
anyone with a render scale off 1.

**A warning when the fallback is taken.** Gated on `scale_factor > 1`, which is the condition for
tiling and nothing else: an ordinary crop or downscale keeps a factor of 1 and stays quiet, and the
factor cannot exceed 1 with the UI shown, since the requested size was clamped to the window
further up.

## Testing

Built Release on Windows (VS 2026), no new warnings. High-resolution snapshots confirmed working
in-world: bloom and chromatic aberration are continuous across the frame, with no tile seams.

Two parts are not exercised at runtime, and I would rather say so than imply otherwise. The
fallback warning needs a capture that genuinely exhausts VRAM, which is the case this PR removes
for ordinary sizes. The restore fix needs `RenderResolutionMultiplier` or `RenderResolutionDivisor`
off 1 and two consecutive captures; it was found by reading, not by hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
